### PR TITLE
Fixed how Signer.swift handles tilde. Added new test case.

### DIFF
--- a/Sources/OCIKit/core/Signer.swift
+++ b/Sources/OCIKit/core/Signer.swift
@@ -128,8 +128,8 @@ public struct APIKeySigner: Signer {
             guard let fingerprint = config["fingerprint"] else { throw ConfigErrors.missingFingerprint }
             guard let userOCID = config["user"] else { throw ConfigErrors.missingUser }
             guard let tenancyOCID = config["tenancy"] else { throw ConfigErrors.missingTenancy }
-            guard let keyfilePath = config["key_file"] else { throw ConfigErrors.missingKeyfile }
-            guard let keyFileContents = try? String(contentsOfFile: keyfilePath, encoding: .utf8) else { throw ConfigErrors.badKeyfile }
+            guard let keyfilePath = config["key_file"] else { throw ConfigErrors.missingKeyfile }         
+            guard let keyFileContents = try? String(contentsOfFile: (keyfilePath as NSString).expandingTildeInPath, encoding: .utf8) else { throw ConfigErrors.badKeyfile }
             guard let privateKey = try? _RSA.Signing.PrivateKey(pemRepresentation: keyFileContents) else { throw ConfigErrors.notPemFormat }
             self.config = Configuration(
                 name: configName,


### PR DESCRIPTION
- Signer.swift tried to read private key path from config file and if you use ~ instead of full path it failed.
- Added a simple test case to verify the existence of the config file. (It should work on Linux as well.)
- Validating config against a fix service (`objectstorage` in other region `us-ashburn-1` ) will fail most probably. Do we have any service without region or shall we use `region` from config file?