### PR TITLE
Upgraded to Swift 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,6 @@
-// swift-tools-version:5.10
+// swift-tools-version: 6.1
+// Copyright 2024 Ilia Sazonov
+// SPDX-License-Identifier: MIT License
 import PackageDescription
 
 let package = Package(

--- a/Sources/OCIKit/core/Signer.swift
+++ b/Sources/OCIKit/core/Signer.swift
@@ -10,7 +10,7 @@ import Crypto
 import _CryptoExtras
 import Logging
 
-public var logger = Logger(label: "OCIKit")
+public let logger = Logger(label: "OCIKit")
 
 // Linux compatibility
 #if canImport(FoundationNetworking)

--- a/Sources/OCIKit/core/X509FederationClientBasedSecurityTokenSigner.swift
+++ b/Sources/OCIKit/core/X509FederationClientBasedSecurityTokenSigner.swift
@@ -17,7 +17,7 @@ public final class X509FederationClientBasedSecurityTokenSigner: Signer {
     public func sign(_ req: inout URLRequest) throws {
         let token = try federationClient.currentSecurityToken()
         let key = try federationClient.currentPrivateKey()
-        var delegateSigner = SecurityTokenSigner(securityToken: token, privateKey: key)
+        let delegateSigner = SecurityTokenSigner(securityToken: token, privateKey: key)
         try delegateSigner.sign(&req)
     }
 }


### PR DESCRIPTION
It seems to be working. 

This function has warning message: "Mutation of captured var 'result' in concurrently-executing code". I tried to rewrite to asynchronous/await but no luck...

```
    static func dataFor(session: URLSession, req: URLRequest) throws -> (Data, URLResponse) {
        var result: Result<(Data, URLResponse), Error>!
        let sem = DispatchSemaphore(value: 1)
        sem.wait()
        let group = DispatchGroup()
        group.enter()
        session.dataTask(with: req) { data, resp, err in
            defer { group.leave() }
            if let err { result = .failure(err) }
            else if let data, let resp { result = .success((data, resp)) }
            else { result = .failure(URLError(.unknown)) }
        }.resume()
        group.wait()
        sem.signal()
        switch result! {
        case .success(let tuple): return tuple
        case .failure(let e): throw e
        }
    }
```