### PR TITLE
Response Headers are case sensitive

### DIFF
--- a/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
+++ b/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
@@ -2613,7 +2613,7 @@ public struct RetryConfig: Sendable {
 func convertHeadersToDictionary(_ httpResponse: HTTPURLResponse) -> [String: String] {
   return httpResponse.allHeaderFields.reduce(into: [String: String]()) { dict, pair in
     if let key = pair.key as? String, let value = pair.value as? String {
-      dict[key] = value
+      dict[key.lowercased()] = value
     }
   }
 }

--- a/Sources/OCIKit/services/Secrets/Secrets.swift
+++ b/Sources/OCIKit/services/Secrets/Secrets.swift
@@ -72,7 +72,8 @@ public struct SecretsClient: Sendable {
     if let endpoint, let endpointURL = URL(string: endpoint) {
       self.endpoint = endpointURL
       self.region = nil
-    } else {
+    }
+    else {
       guard let region else {
         throw SecretsError.missingRequiredParameter("Either endpoint or region must be specified.")
       }
@@ -138,7 +139,8 @@ public struct SecretsClient: Sendable {
     do {
       let secretBundle = try JSONDecoder().decode(SecretBundle.self, from: data)
       return secretBundle
-    } catch {
+    }
+    catch {
       throw SecretsError.jsonDecodingError("Failed to decode response data to SecretBundle: \(error)")
     }
   }
@@ -203,7 +205,8 @@ public struct SecretsClient: Sendable {
     do {
       let secretBundle = try JSONDecoder().decode(SecretBundle.self, from: data)
       return secretBundle
-    } catch {
+    }
+    catch {
       throw SecretsError.jsonDecodingError("Failed to decode response data to SecretBundle: \(error)")
     }
   }
@@ -262,7 +265,8 @@ public struct SecretsClient: Sendable {
     do {
       let versions = try JSONDecoder().decode([SecretBundleVersionSummary].self, from: data)
       return versions
-    } catch {
+    }
+    catch {
       throw SecretsError.jsonDecodingError("Failed to decode response data to [SecretBundleVersionSummary]: \(error)")
     }
   }

--- a/Tests/OCIKit/InstancePrincipalTest.swift
+++ b/Tests/OCIKit/InstancePrincipalTest.swift
@@ -22,7 +22,7 @@ struct InstancePrincipalObjectStorageTest {
     req.setValue("Bearer Oracle", forHTTPHeaderField: "Authorization")
 
     let sem = DispatchSemaphore(value: 0)
-    var result: String?
+    nonisolated(unsafe) var result: String?
     URLSession.shared.dataTask(with: req) { data, resp, err in
       defer { sem.signal() }
       guard err == nil,


### PR DESCRIPTION
Linux `FoundationNetworking` doesn't keep the wire's lowercase.
It title-cases every hyphenated word: `Opc-Content-Md5`, `Opc-Request-Id`, `Version-Id`, `Etag`, `Last-Modified`.

On macOS, the test passed because Darwin's URLSession exposes differently. 

Interesting enough, that technically it doesn't fail on Linux either because it puts the file into the bucket, but the function consider the operation successful only if the headers parsed properly...
