### PR TITLE
Add Linux CI: build + unit tests on arm64 and x86_64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,70 @@
+name: Linux CI
+
+# Builds OCIKit and its test targets on Linux, then runs the credential-free
+# unit tests. Runs on every pull request and can be triggered manually.
+#
+# Why only *some* tests run here:
+#   Most of the suites under Tests/ are live integration tests. They construct
+#   `APIKeySigner(configFilePath:...)`, which reads ~/.oci/config and throws
+#   `ConfigErrors.missingConfig` when it is absent — so they fail on any runner
+#   without real OCI credentials (and some are destructive, e.g. IAM bulk delete).
+#   CI therefore runs ONLY the pure unit suites listed in UNIT_TEST_FILTER below.
+#   The `swift build --build-tests` step still compiles ALL targets, so a Linux
+#   compile break in any test (or in the library) still fails the build.
+#
+# Adding a new unit test suite? Add its type name to UNIT_TEST_FILTER.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: linux-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Regex (OR-separated) of swift-testing suite type names that are pure unit
+  # tests — no ~/.oci/config, no network, no env vars. These MUST pass in CI.
+  UNIT_TEST_FILTER: >-
+    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests
+
+jobs:
+  build-and-test:
+    name: Build & unit tests (${{ matrix.runner }}, Swift ${{ matrix.swift }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run on both x86_64 (ubuntu-latest) and arm64 (ubuntu-24.04-arm) Linux.
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        # The container tag must be >= the swift-tools-version in Package.swift (6.2).
+        # Add e.g. "6.3" here to test additional toolchains.
+        swift: ["6.2"]
+    container:
+      # Multi-arch image: resolves to linux/amd64 or linux/arm64 to match the runner.
+      image: swift:${{ matrix.swift }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Cache .build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ matrix.runner }}-spm-${{ matrix.swift }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ matrix.runner }}-spm-${{ matrix.swift }}-
+
+      - name: Resolve dependencies
+        run: swift package resolve
+
+      # Compiling the library AND every test target is the primary Linux signal:
+      # a Linux-only compile error (e.g. a @Sendable capture) fails here.
+      - name: Build (library + tests)
+        run: swift build --build-tests
+
+      - name: Run unit tests (credential-free)
+        run: swift test --skip-build --filter "$UNIT_TEST_FILTER"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,13 +45,13 @@ jobs:
       image: swift:${{ matrix.swift }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Swift version
         run: swift --version
 
       - name: Cache .build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .build
           key: ${{ matrix.runner }}-spm-${{ matrix.swift }}-${{ hashFiles('Package.resolved') }}

--- a/Tests/OCIKit/InstancePrincipalTest.swift
+++ b/Tests/OCIKit/InstancePrincipalTest.swift
@@ -14,32 +14,31 @@ import Testing
 #endif
 
 struct InstancePrincipalObjectStorageTest {
-  private func fetchIMDSRegion(timeoutSeconds: TimeInterval = 5) -> String? {
+  private func fetchIMDSRegion(timeoutSeconds: TimeInterval = 5) async -> String? {
     let base = ProcessInfo.processInfo.environment["OCI_METADATA_BASE_URL"] ?? "http://169.254.169.254/opc/v2"
     guard let url = URL(string: "\(base)/instance/region") else { return nil }
     var req = URLRequest(url: url)
     req.httpMethod = "GET"
     req.setValue("Bearer Oracle", forHTTPHeaderField: "Authorization")
+    req.timeoutInterval = timeoutSeconds
 
-    let sem = DispatchSemaphore(value: 0)
-    var result: String?
-    URLSession.shared.dataTask(with: req) { data, resp, err in
-      defer { sem.signal() }
-      guard err == nil,
-        let data = data,
-        let http = resp as? HTTPURLResponse,
-        (200..<300).contains(http.statusCode)
-      else { return }
-      result = String(data: data, encoding: .utf8)?
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-        .lowercased()
-    }.resume()
-    _ = sem.wait(timeout: .now() + timeoutSeconds)
-    return result
+    // Use the async URLSession API. On Apple platforms this is the native method;
+    // on Linux it resolves to the shim in core/URLSession+Linux.swift. This avoids
+    // mutating a captured var inside a @Sendable completion handler, which is a hard
+    // error under strict concurrency on swift-corelibs-foundation (Linux).
+    guard
+      let (data, resp) = try? await URLSession.shared.data(for: req),
+      let http = resp as? HTTPURLResponse,
+      (200..<300).contains(http.statusCode)
+    else { return nil }
+
+    return String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
   }
 
   @Test func getNamespace_withInstancePrincipalSigner() async throws {
-    guard let regionRaw = fetchIMDSRegion() else {
+    guard let regionRaw = await fetchIMDSRegion() else {
       print("Skipping Instance Principal test: IMDS region unavailable (not running on OCI instance?)")
       return
     }


### PR DESCRIPTION
## What

Adds a Linux CI workflow and fixes the one Linux-only test compile error that was blocking it. Restores CI on this repo (the previous `ci.yml` was removed because it "failed all the time").

### `.github/workflows/linux.yml` (new)
- Builds `OCIKit` + **all** test targets (`swift build --build-tests`), then runs the credential-free unit suites (`swift test --filter`) on Linux.
- Matrix over **x86_64 (`ubuntu-latest`)** and **arm64 (`ubuntu-24.04-arm`)**, in the `swift:6.2` container. `.build` cached per-arch.
- Triggers: every **pull request** + manual **workflow_dispatch**.

Integration tests are intentionally excluded from the run: they construct `APIKeySigner(...)`, which reads `~/.oci/config` and throws `missingConfig` without it — so they can't pass on a stock runner (and some are destructive, e.g. IAM bulk-delete). The build step still compiles every test target, so a Linux compile break anywhere still fails CI. To add a new unit suite, append its type name to `UNIT_TEST_FILTER` in the workflow.

### `Tests/OCIKit/InstancePrincipalTest.swift` (fix)
`fetchIMDSRegion` mutated a captured `var` inside a `@Sendable` `URLSession.dataTask` completion handler — a hard error under strict concurrency on swift-corelibs-foundation, so `swift test` could not even build on Linux. Switched to async `URLSession.data(for:)` (native on Apple platforms; the repo's existing `URLSession+Linux.swift` shim on Linux) and dropped the `DispatchSemaphore`. Still self-skips when not on an OCI instance.

## Verification

Ran the exact CI commands in `swift:6.2` containers (Swift 6.2.4):

| Target | Build (lib + tests) | 25 unit tests |
|---|---|---|
| linux/amd64 (x86_64) | ✅ | ✅ |
| linux/arm64 | ✅ | ✅ |
| macOS (Swift 6.3.3) | ✅ | — |
