### PR TITLE
Fix Object Storage/IAM response-header parsing on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ Support for OCI services is being added incrementally, starting with those curre
 ## TODO List
 - [x] API Key authN
 - [x] GenAI inference (common models)
-- [ ] Instance Principal authN
+- [x] Instance Principal authN
 - [ ] Resource Principal authN
-- [ ] Object Storage
+- [x] Object Storage
 - [ ] Container Instances
-- [ ] GenAI inference (custom models)
+- [x] GenAI inference (custom models)
+- [x] Identity & Access Management (compartments)
+- [x] Secrets (secret bundles)
+- [x] AI Language (health entity detection)
 
 ## License
 

--- a/Sources/OCIKit/services/Identity and Access Management/IAM.swift
+++ b/Sources/OCIKit/services/Identity and Access Management/IAM.swift
@@ -106,8 +106,7 @@ public struct IAMClient: Sendable {
       throw IAMError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcWorkRequestId = headers["opc-work-request-id"], let opcRequestId = headers["opc-request-id"] {
+    if let opcWorkRequestId = httpResponse.value(forHTTPHeaderField: "opc-work-request-id"), let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id") {
       logger.debug("opc-work-request-id: \(opcWorkRequestId), opc-request-id: \(opcRequestId)")
     }
   }
@@ -172,8 +171,7 @@ public struct IAMClient: Sendable {
       throw IAMError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcWorkRequestId = headers["opc-work-request-id"], let opcRequestId = headers["opc-request-id"] {
+    if let opcWorkRequestId = httpResponse.value(forHTTPHeaderField: "opc-work-request-id"), let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id") {
       logger.debug("opc-work-request-id: \(opcWorkRequestId), opc-request-id: \(opcRequestId)")
     }
   }
@@ -274,8 +272,7 @@ public struct IAMClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcWorkRequestId = headers["opc-work-request-id"], let opcRequestId = headers["opc-request-id"] {
+    if let opcWorkRequestId = httpResponse.value(forHTTPHeaderField: "opc-work-request-id"), let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id") {
       logger.debug("opc-work-request-id: \(opcWorkRequestId), opc-request-id: \(opcRequestId)")
     }
   }
@@ -523,8 +520,7 @@ public struct IAMClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcWorkRequestId = headers["opc-work-request-id"], let opcRequestId = headers["opc-request-id"] {
+    if let opcWorkRequestId = httpResponse.value(forHTTPHeaderField: "opc-work-request-id"), let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id") {
       logger.debug("opc-work-request-id: \(opcWorkRequestId), opc-request-id: \(opcRequestId)")
     }
   }

--- a/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
+++ b/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
@@ -88,9 +88,8 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcRequestId = headers["opc-request-id"],
-      let opcClientRequestId = headers["opc-client-request-id"]
+    if let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"),
+      let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id")
     {
       logger.debug("opc-request-id: \(opcRequestId), opc-client-request-id: \(opcClientRequestId)")
     }
@@ -150,8 +149,7 @@ public struct ObjectStorageClient: Sendable {
         throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
       }
 
-      let headers = convertHeadersToDictionary(httpResponse)
-      if let opcRequestId = headers["opc-request-id"], let opcWorkRequestId = headers["opc-work-request-id"], let opcClientRequestId = headers["opc-client-request-id"] {
+      if let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"), let opcWorkRequestId = httpResponse.value(forHTTPHeaderField: "opc-work-request-id"), let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id") {
         logger.debug("opc-request-id: \(opcRequestId), opc-work-request-id: \(opcWorkRequestId), opc-client-request-id: \(opcClientRequestId)")
       }
     }
@@ -428,8 +426,7 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcRequestId = headers["opc-request-id"] {
+    if let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id") {
       logger.debug("The \(bucketName) bucket was delete from \(namespaceName) namespace. RequestID: \(opcRequestId)")
     }
   }
@@ -477,9 +474,8 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let isDeleteMarker = headers["is-delete-marker"], let lastModified = headers["last-modified"], let opcClientRequestId = headers["opc-client-request-id"],
-      let opcRequestId = headers["opc-request-id"], let versionId = headers["version-id"]
+    if let isDeleteMarker = httpResponse.value(forHTTPHeaderField: "is-delete-marker"), let lastModified = httpResponse.value(forHTTPHeaderField: "last-modified"), let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"),
+      let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"), let versionId = httpResponse.value(forHTTPHeaderField: "version-id")
     {
       logger.debug("is-delete-marker: \(isDeleteMarker), last-modified: \(lastModified), opc-client-request-id: \(opcClientRequestId), opc-request-id: \(opcRequestId), version-id: \(versionId)")
     }
@@ -530,9 +526,8 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcRequestId = headers["opc-request-id"],
-      let opcClientRequestId = headers["opc-client-request-id"]
+    if let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"),
+      let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id")
     {
       logger.debug("opc-request-id: \(opcRequestId), opc-client-request-id: \(opcClientRequestId)")
     }
@@ -585,9 +580,8 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcRequestId = headers["opc-request-id"],
-      let opcClientRequestId = headers["opc-client-request-id"]
+    if let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"),
+      let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id")
     {
       logger.debug("opc-request-id: \(opcRequestId), opc-client-request-id: \(opcClientRequestId)")
     }
@@ -639,9 +633,8 @@ public struct ObjectStorageClient: Sendable {
 
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcClientRequestId = headers["opc-client-request-id"],
-      let opcRequestId = headers["opc-request-id"]
+    if let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"),
+      let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id")
     {
       logger.debug("opc-client-request-id: \(opcClientRequestId), opc-request-id: \(opcRequestId)")
     }
@@ -1210,8 +1203,7 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let etag = headers["ETag"], let opcRequestId = headers["opc-request-id"] {
+    if let etag = httpResponse.value(forHTTPHeaderField: "etag"), let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id") {
       logger.debug("ETag: \(etag), opc-request-id: \(opcRequestId)")
     }
   }
@@ -1275,28 +1267,35 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-
-    if let etag = headers["ETag"],
-      let archivalState = headers["archival-state"],
-      let cacheControl = headers["cache-control"],
-      let contentDisposition = headers["content-disposition"],
-      let contentEncoding = headers["content-encoding"],
-      let contentLanguage = headers["content-language"],
-      let contentLength = headers["content-length"],
-      let contentMd5 = headers["content-md5"],
-      let contentType = headers["content-type"],
-      let lastModified = headers["last-modified"],
-      let opcClientRequestId = headers["opc-client-request-id"],
-      let opcMultipartMd5 = headers["opc-multipart-md5"],
-      let opcRequestId = headers["opc-request-id"],
-      let storageTier = headers["storage-tier"],
-      let timeOfArchival = headers["time-of-archival"],
-      let versionId = headers["version-id"]
+    if let etag = httpResponse.value(forHTTPHeaderField: "etag"),
+      let archivalState = httpResponse.value(forHTTPHeaderField: "archival-state"),
+      let cacheControl = httpResponse.value(forHTTPHeaderField: "cache-control"),
+      let contentDisposition = httpResponse.value(forHTTPHeaderField: "content-disposition"),
+      let contentEncoding = httpResponse.value(forHTTPHeaderField: "content-encoding"),
+      let contentLanguage = httpResponse.value(forHTTPHeaderField: "content-language"),
+      let contentLength = httpResponse.value(forHTTPHeaderField: "content-length"),
+      let contentMd5 = httpResponse.value(forHTTPHeaderField: "content-md5"),
+      let contentType = httpResponse.value(forHTTPHeaderField: "content-type"),
+      let lastModified = httpResponse.value(forHTTPHeaderField: "last-modified"),
+      let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"),
+      let opcMultipartMd5 = httpResponse.value(forHTTPHeaderField: "opc-multipart-md5"),
+      let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"),
+      let storageTier = httpResponse.value(forHTTPHeaderField: "storage-tier"),
+      let timeOfArchival = httpResponse.value(forHTTPHeaderField: "time-of-archival"),
+      let versionId = httpResponse.value(forHTTPHeaderField: "version-id")
     {
 
-      // Extract all user-defined metadata headers
-      let opcMeta = headers.filter { $0.key.hasPrefix("opc-meta-") }
+      // Extract all user-defined metadata headers. Match case-insensitively and
+      // normalize the keys to lower case, because swift-corelibs-foundation on Linux
+      // capitalizes response header names (e.g. `Opc-Meta-Foo`) while Darwin preserves
+      // the server's original casing (`opc-meta-foo`).
+      let opcMeta = httpResponse.allHeaderFields.reduce(into: [String: String]()) { result, pair in
+        if let key = pair.key as? String, let value = pair.value as? String,
+          key.lowercased().hasPrefix("opc-meta-")
+        {
+          result[key.lowercased()] = value
+        }
+      }
 
       logger.debug(
         """
@@ -1879,10 +1878,8 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-
-    if let opcClientRequestId = headers["opc-client-request-id"],
-      let opcRequestId = headers["opc-request-id"]
+    if let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"),
+      let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id")
     {
       logger.debug("opc-client-request-id: \(opcClientRequestId), opc-request-id: \(opcRequestId)")
     }
@@ -1954,18 +1951,16 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-
-    guard let etag = headers["Etag"],
-      let lastModified = headers["Last-Modified"],
-      let opcContentMd5 = headers["opc-content-md5"],
-      let opcRequestId = headers["opc-request-id"],
-      let versionId = headers["version-id"]
+    guard let etag = httpResponse.value(forHTTPHeaderField: "etag"),
+      let lastModified = httpResponse.value(forHTTPHeaderField: "last-modified"),
+      let opcContentMd5 = httpResponse.value(forHTTPHeaderField: "opc-content-md5"),
+      let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"),
+      let versionId = httpResponse.value(forHTTPHeaderField: "version-id")
     else {
       throw ObjectStorageError.invalidResponse("Missing required response headers")
     }
 
-    let opcClientRequestId = headers["opc-client-request-id"] ?? "nil"
+    let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id") ?? "nil"
 
     self.logger.info(
       """
@@ -2044,18 +2039,16 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-
-    guard let etag = headers["Etag"],
-      let lastModified = headers["Last-Modified"],
-      let opcContentMd5 = headers["opc-content-md5"],
-      let opcRequestId = headers["opc-request-id"],
-      let versionId = headers["version-id"]
+    guard let etag = httpResponse.value(forHTTPHeaderField: "etag"),
+      let lastModified = httpResponse.value(forHTTPHeaderField: "last-modified"),
+      let opcContentMd5 = httpResponse.value(forHTTPHeaderField: "opc-content-md5"),
+      let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"),
+      let versionId = httpResponse.value(forHTTPHeaderField: "version-id")
     else {
       throw ObjectStorageError.invalidResponse("Missing required response headers")
     }
 
-    let opcClientRequestId = headers["opc-client-request-id"] ?? "nil"
+    let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id") ?? "nil"
 
     self.logger.info(
       """
@@ -2116,8 +2109,7 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    let headers = convertHeadersToDictionary(httpResponse)
-    if let opcRequestId = headers["opc-request-id"], let opcWorkRequestId = headers["opc-work-request-id"] {
+    if let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"), let opcWorkRequestId = httpResponse.value(forHTTPHeaderField: "opc-work-request-id") {
       logger.debug("opc-request-id: \(opcRequestId), opc-work-request-id: \(opcWorkRequestId)")
     }
   }
@@ -2182,8 +2174,7 @@ public struct ObjectStorageClient: Sendable {
         throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
       }
 
-      let headers = convertHeadersToDictionary(httpResponse)
-      if let opcClientRequestId = headers["opc-client-request-id"], let opcRequestId = headers["opc-request-id"] {
+      if let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"), let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id") {
         logger.debug("opc-client-request-id: \(opcClientRequestId), opc-request-id: \(opcRequestId)")
       }
     }
@@ -2243,13 +2234,11 @@ public struct ObjectStorageClient: Sendable {
         throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
       }
 
-      let headers = convertHeadersToDictionary(httpResponse)
-
-      if let etag = headers["ETag"],
-        let lastModified = headers["last-modified"],
-        let opcClientRequestId = headers["opc-client-request-id"],
-        let opcRequestId = headers["opc-request-id"],
-        let versionId = headers["version-id"]
+      if let etag = httpResponse.value(forHTTPHeaderField: "etag"),
+        let lastModified = httpResponse.value(forHTTPHeaderField: "last-modified"),
+        let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"),
+        let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"),
+        let versionId = httpResponse.value(forHTTPHeaderField: "version-id")
       {
 
         logger.debug(
@@ -2312,9 +2301,7 @@ public struct ObjectStorageClient: Sendable {
         throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
       }
 
-      let headers = convertHeadersToDictionary(httpResponse)
-
-      if let opcClientRequestId = headers["opc-client-request-id"], let opcRequestId = headers["opc-request-id"] {
+      if let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"), let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id") {
         logger.debug(
           """
           opc-client-request-id: \(opcClientRequestId)
@@ -2528,9 +2515,7 @@ public struct ObjectStorageClient: Sendable {
         throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
       }
 
-      let headers = convertHeadersToDictionary(httpResponse)
-
-      if let opcClientRequestId = headers["opc-client-request-id"], let opcRequestId = headers["opc-request-id"] {
+      if let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"), let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id") {
         logger.debug(
           """
           opc-client-request-id: \(opcClientRequestId)
@@ -2606,14 +2591,4 @@ public struct ObjectStorageClient: Sendable {
 public struct RetryConfig: Sendable {
   let maxAttempts: Int
   let baseDelay: TimeInterval
-}
-
-// Convert HTTPURLResponse to dictionary
-// TODO: Move to utility file
-func convertHeadersToDictionary(_ httpResponse: HTTPURLResponse) -> [String: String] {
-  return httpResponse.allHeaderFields.reduce(into: [String: String]()) { dict, pair in
-    if let key = pair.key as? String, let value = pair.value as? String {
-      dict[key] = value
-    }
-  }
 }

--- a/Tests/Linux/PutObjectHeaderCasingDiagnostics.swift
+++ b/Tests/Linux/PutObjectHeaderCasingDiagnostics.swift
@@ -1,0 +1,155 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+//
+// Diagnostics for the reported issue: on Linux `putObject` threw even though
+// the object was successfully uploaded. Root cause: response-header casing.
+//
+// The SDK used to look up response headers with exact-case keys against a plain,
+// case-sensitive `[String: String]` built from `HTTPURLResponse.allHeaderFields`.
+// swift-corelibs-foundation (Linux) normalizes response header names to capitalized
+// "Http-Header-Case" (e.g. `Opc-Request-Id`), while Darwin preserves the server's
+// original casing for custom headers (`opc-request-id`). The lowercase lookups
+// therefore missed on Linux and `putObject` threw `.invalidResponse("Missing
+// required response headers")` AFTER the server already returned 200.
+//
+// The fix reads every header via `HTTPURLResponse.value(forHTTPHeaderField:)`,
+// which is case-insensitive on both platforms. These tests both reproduce the
+// original failure and prove the fix: run them on macOS and Linux and compare.
+//
+
+import Foundation
+import OCIKit
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+struct PutObjectHeaderCasingDiagnostics {
+  let configPath: String
+  let profile: String
+  let bucketName: String
+
+  init() {
+    let env = ProcessInfo.processInfo.environment
+    configPath = env["OCI_CONFIG_FILE"] ?? "\(NSHomeDirectory())/.oci/config"
+    profile = env["OCI_PROFILE"] ?? "DEFAULT"
+    bucketName = env["OCI_TEST_BUCKET"] ?? "myTestBucket"
+  }
+
+  private var platform: String {
+    #if os(Linux)
+      return "Linux"
+    #else
+      return "Darwin"
+    #endif
+  }
+
+  /// Builds the signer and a service endpoint from the DEFAULT profile.
+  private func makeSignerAndEndpoint() throws -> (signer: APIKeySigner, endpoint: URL, region: Region) {
+    let regionId = (try extractUserRegion(from: configPath, profile: profile)) ?? "us-ashburn-1"
+    let region = Region.from(regionId: regionId) ?? .iad
+    let signer = try APIKeySigner(configFilePath: configPath, configName: profile)
+    // Same endpoint shape the client builds internally: https://<host>/n
+    guard let endpoint = URL(string: "https://objectstorage.\(regionId).oraclecloud.com/n") else {
+      throw ObjectStorageError.invalidURL("Could not build endpoint for region \(regionId)")
+    }
+    return (signer, endpoint, region)
+  }
+
+  // MARK: - 1. Dump the real response-header casing from a live PutObject
+  //
+  // Performs the SAME request `putObject` performs, but prints the headers
+  // verbatim so the exact casing Foundation produces on this platform is visible.
+  @Test("Dump real PutObject response-header casing")
+  func dumpRealResponseHeaderCasing() async throws {
+    let (signer, endpoint, region) = try makeSignerAndEndpoint()
+    let client = try ObjectStorageClient(region: region, signer: signer)
+    let namespace = try await client.getNamespace()
+
+    print("\n========== [\(platform)] PutObject header-casing diagnostic ==========")
+    print("namespace: \(namespace)  bucket: \(bucketName)")
+
+    let objectName = "linux-header-casing-test.txt"
+    let body = Data("Hello from \(platform)".utf8)
+
+    // Mirror ObjectStorageClient.putObject request construction.
+    let api = ObjectStorageAPI.putObject(
+      namespaceName: namespace,
+      bucketName: bucketName,
+      objectName: objectName
+    )
+    var req = try buildRequest(api: api, endpoint: endpoint)
+    req.httpBody = body
+    try signer.sign(&req)
+
+    let (data, response) = try await URLSession.shared.data(for: req)
+    let http = try #require(response as? HTTPURLResponse)
+    print("HTTP status: \(http.statusCode)  (200 == server stored the object)")
+    if http.statusCode != 200 {
+      print("response body: \(String(data: data, encoding: .utf8) ?? "<non-utf8>")")
+    }
+
+    // Build the OLD case-sensitive dictionary to show how the previous code failed.
+    let dict = http.allHeaderFields.reduce(into: [String: String]()) { acc, pair in
+      if let k = pair.key as? String, let v = pair.value as? String { acc[k] = v }
+    }
+
+    print("--- allHeaderFields keys, verbatim (\(dict.count)) ---")
+    for k in dict.keys.sorted() { print("    '\(k)' = \(dict[k]!)") }
+
+    let sdkKeys = ["etag", "last-modified", "opc-content-md5", "opc-request-id", "version-id"]
+    print("--- OLD case-sensitive dict lookups (what the bug did) ---")
+    for key in sdkKeys {
+      print("    dict[\"\(key)\"] -> \(dict[key] != nil ? "FOUND" : "nil  <-- guard failed here")")
+    }
+
+    print("--- NEW value(forHTTPHeaderField:) lookups (the fix) ---")
+    for key in sdkKeys {
+      let v = http.value(forHTTPHeaderField: key)
+      print("    value(\"\(key)\") -> \(v != nil ? "FOUND" : "nil")")
+    }
+    print("======================================================================\n")
+
+    #expect(http.statusCode == 200, "The upload itself must succeed (server returns 200)")
+  }
+
+  // MARK: - 2. Reproduce/verify through the public API
+  //
+  // Before the fix this threw on Linux; after the fix it must return normally
+  // on both platforms even though the object was uploaded.
+  @Test("client.putObject returns cleanly after a successful upload")
+  func reproduceUserBug() async throws {
+    let (signer, _, region) = try makeSignerAndEndpoint()
+    let client = try ObjectStorageClient(region: region, signer: signer)
+    let namespace = try await client.getNamespace()
+
+    do {
+      try await client.putObject(
+        namespaceName: namespace,
+        bucketName: bucketName,
+        objectName: "linux-putobject-repro.txt",
+        putObjectBody: Data("repro".utf8)
+      )
+      print("=== [\(platform)] putObject returned normally (no error) ===")
+    }
+    catch {
+      print("=== [\(platform)] putObject THREW after a successful upload ===")
+      print("    error: \(error)")
+      print("    localizedDescription: \(error.localizedDescription)")
+      Issue.record("putObject threw despite the object being uploaded: \(error.localizedDescription)")
+    }
+  }
+}


### PR DESCRIPTION
> Originally discovered and diagnosed by @kicsipixel in #67 ("Response Headers are case sensitive"), who pinned down that Linux `FoundationNetworking` title-cases every hyphenated header word (`Opc-Content-Md5`, `Opc-Request-Id`, `Version-Id`, …) and noted the object is still uploaded even though the call reports failure. This PR implements the fix for that issue and can supersede #67.

## Problem

A user reported that on **Linux**, `ObjectStorageClient.putObject` throws even though the file is successfully uploaded (the object lands in the bucket, but the call fails and the error surfaced to the caller as a "500"). This confirms @kicsipixel's report in #67.

## Root cause

Response headers were read from a case-sensitive `[String: String]` built by `convertHeadersToDictionary(_:)` from `HTTPURLResponse.allHeaderFields`, then looked up with fixed-case string keys (`headers["opc-content-md5"]`, `headers["version-id"]`, …).

The two Foundations normalize response header names differently:

- **Darwin (CFNetwork):** canonicalizes only a few well-known headers (`ETag`→`Etag`, `Last-Modified`) and passes non-standard headers through **verbatim** (`opc-request-id`, `version-id`, …), matching the hardcoded keys. So it worked on macOS/iOS.
- **Linux (swift-corelibs-foundation):** normalizes **every** header name to capitalized "Http-Header-Case" — `Opc-Request-Id`, `Opc-Content-Md5`, `Version-Id`. The lowercase custom-header lookups miss, the guard fails, and `putObject` throws `invalidResponse("Missing required response headers")` **after** the server already returned `200`.

`ETag`/`Last-Modified` normalize identically on both platforms, which masked part of the bug. The same pattern affected ~24 sites across `ObjectStorage.swift` and `IAM.swift`.

## Fix

Read every header via `HTTPURLResponse.value(forHTTPHeaderField:)`, which is **case-insensitive on both** Darwin and swift-corelibs-foundation, and remove the `convertHeadersToDictionary` helper entirely. The single site that enumerates unknown headers (`headObject`'s `opc-meta-*` scan) now iterates `allHeaderFields` with a **case-insensitive prefix** match and lower-cases the returned keys so metadata is consistent across platforms.

Net: **67 insertions, 96 deletions** in the two source files — less code, and no bespoke case handling.

## Verification

Added `Tests/Linux/PutObjectHeaderCasingDiagnostics.swift` (live integration test, "Tests on Linux" target — not part of the CI unit filter). Run against a real bucket on both platforms:

- **`client.putObject` returns cleanly on Linux** (previously threw after a successful upload).
- The dump confirms the mechanism: on Linux the stored keys are `Opc-Content-Md5`/`Opc-Request-Id`/`Version-Id`, so the old case-sensitive lookups return `nil` while `value(forHTTPHeaderField:)` returns the value; macOS is the mirror image.

```
swift test --filter 'dumpRealResponseHeaderCasing|reproduceUserBug'
# Linux: docker run --rm -v "$PWD":/workspace -v ~/.oci:<same path>:ro \
#   -e OCI_CONFIG_FILE=... -e OCI_PROFILE=DEFAULT -w /workspace swift:6.2 \
#   swift test --scratch-path /tmp/build-linux --filter '...'
```

Both suites pass on macOS (Swift 6.3) and Linux (`swift:6.2`).
