### PR TITLE
Add Resource Principal v2.2 auth and Container Instances client

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ env:
   # Regex (OR-separated) of swift-testing suite type names that are pure unit
   # tests — no ~/.oci/config, no network, no env vars. These MUST pass in CI.
   UNIT_TEST_FILTER: >-
-    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests
+    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests|ResourcePrincipalSourceTests|ResourcePrincipalTokenTests|ResourcePrincipalEnvironmentTests|ResourcePrincipalSigningTests|ContainerInstancesRouterTests|ContainerInstancesEnumsTests|ContainerInstancesModelEncodingTests|ContainerInstancesModelDecodingTests
 
 jobs:
   build-and-test:

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,8 @@ postgres/oracle_fdw/**
 
 # Oracle wallet files
 oracle/*.pem
+
+# Claude
+.claude/
+CLAUDE.md
+

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Support for OCI services is being added incrementally, starting with those curre
 - [x] API Key authN
 - [x] GenAI inference (common models)
 - [x] Instance Principal authN
-- [ ] Resource Principal authN
+- [x] Resource Principal authN (v2.2 — Container Instances, Functions, Data Science)
+- [ ] OKE Workload Identity authN (planned — needs custom-CA TLS to the in-cluster proxymux)
 - [x] Object Storage
-- [ ] Container Instances
+- [x] Container Instances
 - [x] GenAI inference (custom models)
 - [x] Identity & Access Management (compartments)
 - [x] Secrets (secret bundles)

--- a/Sources/OCIKit/core/Region+Service.swift
+++ b/Sources/OCIKit/core/Region+Service.swift
@@ -69,7 +69,7 @@ public enum Region: String, CaseIterable, Sendable {
 }
 
 public enum Service: String {
-  case language, objectstorage, generativeai, iam, secrets
+  case language, objectstorage, generativeai, iam, secrets, containerinstances
 
   func getHost(in region: Region) -> String {
     switch self {
@@ -83,6 +83,8 @@ public enum Service: String {
       "identity.\(region.urlPart).oci.oraclecloud.com"
     case .secrets:
       "secrets.vaults.\(region.urlPart).oci.oraclecloud.com"
+    case .containerinstances:
+      "compute-containers.\(region.urlPart).oci.oraclecloud.com"
     }
   }
 }

--- a/Sources/OCIKit/core/ResourcePrincipalSigner.swift
+++ b/Sources/OCIKit/core/ResourcePrincipalSigner.swift
@@ -1,0 +1,296 @@
+//
+//  ResourcePrincipalSigner.swift
+//  OCIKit
+//
+//  Implements OCI Resource Principals **v2.2** authentication, mirroring
+//  `oci/auth/signers/ephemeral_resource_principals_signer.py`
+//  (`EphemeralResourcePrincipalSigner`) from the Python SDK.
+//
+//  Resource Principals let workloads that run inside certain OCI services
+//  (Functions, **Container Instances**, Data Science, etc.) authenticate to
+//  other OCI services without an API key. For v2.2 the hosting service injects
+//  the session token (RPST) and its matching private key into the container's
+//  environment; the SDK simply signs requests with keyId `ST$<rpst>` using that
+//  key — there is **no** network round-trip at construction or sign time.
+//
+//  Environment variables (read by ``ResourcePrincipalSigner/fromEnvironment(_:)``):
+//    - `OCI_RESOURCE_PRINCIPAL_VERSION`               — must be `"2.2"`.
+//    - `OCI_RESOURCE_PRINCIPAL_RPST`                  — the RPST, either the raw
+//      token value or an **absolute path** to a file containing it.
+//    - `OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM`           — the private key, either a
+//      raw PEM string or an **absolute path** to a PEM file.
+//    - `OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM_PASSPHRASE`— optional passphrase.
+//      Encrypted keys are not supported by swift-crypto; see note below.
+//    - `OCI_RESOURCE_PRINCIPAL_REGION`                — optional region id.
+//
+//  As in the Python SDK, whether a value is a literal or a file path is decided
+//  purely by whether the string is an absolute path (begins with `/`). File-based
+//  values are re-read on refresh so that a rotated RPST/key on disk is picked up.
+//
+
+import Crypto
+import Foundation
+import _CryptoExtras
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// MARK: - Errors
+
+/// Errors raised while constructing or using a ``ResourcePrincipalSigner``.
+public enum ResourcePrincipalError: Error, LocalizedError, Equatable {
+  /// `OCI_RESOURCE_PRINCIPAL_VERSION` is not set in the environment.
+  case versionNotDefined
+  /// `OCI_RESOURCE_PRINCIPAL_VERSION` is set to a value this SDK does not support.
+  case unsupportedVersion(String)
+  /// `OCI_RESOURCE_PRINCIPAL_RPST` is missing or resolved to an empty token.
+  case missingSessionToken
+  /// `OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM` is missing.
+  case missingPrivateKey
+  /// The resolved private key could not be parsed as an RSA PEM key.
+  case invalidPrivateKey
+  /// A file referenced by an RP environment variable could not be read.
+  case fileReadFailed(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .versionNotDefined:
+      return "OCI_RESOURCE_PRINCIPAL_VERSION is not defined"
+    case .unsupportedVersion(let v):
+      return "Unsupported OCI_RESOURCE_PRINCIPAL_VERSION: \(v)"
+    case .missingSessionToken:
+      return "OCI_RESOURCE_PRINCIPAL_RPST was not provided. Resource principals authentication can only be used in certain OCI services."
+    case .missingPrivateKey:
+      return "OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM must be provided. Resource principals authentication can only be used in certain OCI services."
+    case .invalidPrivateKey:
+      return "The resource principal private key is not a valid RSA PEM key (encrypted keys are not supported)"
+    case .fileReadFailed(let path):
+      return "Failed to read resource principal material from file: \(path)"
+    }
+  }
+}
+
+// MARK: - Environment variable names
+
+/// The exact environment-variable names read for Resource Principals v2.2.
+enum ResourcePrincipalEnv {
+  static let version = "OCI_RESOURCE_PRINCIPAL_VERSION"
+  static let rpst = "OCI_RESOURCE_PRINCIPAL_RPST"
+  static let privatePem = "OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM"
+  static let passphrase = "OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM_PASSPHRASE"
+  static let region = "OCI_RESOURCE_PRINCIPAL_REGION"
+
+  /// The only Resource Principal version this signer implements.
+  static let supportedVersion = "2.2"
+}
+
+// MARK: - Value sources (literal vs. file path)
+
+/// A string-valued RP input that is either a literal value or an absolute file path.
+///
+/// Matches the Python SDK's `os.path.isabs(...)` decision: any value beginning
+/// with `/` is treated as a filesystem path, everything else as a literal.
+enum ResourcePrincipalSource: Equatable {
+  case value(String)
+  case file(String)
+
+  /// Classifies a raw environment value into a literal or a file path.
+  static func detect(_ raw: String) -> ResourcePrincipalSource {
+    raw.hasPrefix("/") ? .file(raw) : .value(raw)
+  }
+
+  /// Resolves the source to its current string contents, reading the file each
+  /// time so that rotated on-disk material is picked up on refresh.
+  func resolve() throws -> String {
+    switch self {
+    case .value(let v):
+      return v
+    case .file(let path):
+      guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+        throw ResourcePrincipalError.fileReadFailed(path)
+      }
+      return contents
+    }
+  }
+}
+
+// MARK: - ResourcePrincipalSigner
+
+/// A ``Signer`` that authenticates using OCI Resource Principals v2.2.
+///
+/// The signer caches the current RPST and private key and, before signing,
+/// transparently refreshes them once the token is within 60 seconds of its JWT
+/// `exp` (matching the Python SDK's default jitter). When the RPST or key were
+/// supplied as file paths, refresh re-reads them from disk.
+///
+/// ## Example
+/// ```swift
+/// // Inside a Container Instance / Function where OCI injects the RP env vars:
+/// let signer = try ResourcePrincipalSigner.fromEnvironment()
+/// let client = try ObjectStorageClient(region: .fra, signer: signer)
+/// ```
+public final class ResourcePrincipalSigner: Signer, @unchecked Sendable {
+  private let rpstSource: ResourcePrincipalSource
+  private let keySource: ResourcePrincipalSource
+
+  /// The region id reported by `OCI_RESOURCE_PRINCIPAL_REGION`, if any.
+  /// Used by callers to select a service endpoint; not part of signing.
+  public let region: String?
+
+  /// Seconds before the RPST `exp` at which the token is treated as expired.
+  private static let expiryJitterSeconds = 60
+
+  private let lock = NSLock()
+  private var cachedToken: String?
+  private var cachedKey: _RSA.Signing.PrivateKey?
+  private var cachedExpiry: Int?
+
+  // MARK: Designated init
+
+  init(rpstSource: ResourcePrincipalSource, keySource: ResourcePrincipalSource, region: String?) {
+    self.rpstSource = rpstSource
+    self.keySource = keySource
+    self.region = region
+  }
+
+  // MARK: Public constructors
+
+  /// Builds a signer from the Resource Principals environment variables.
+  ///
+  /// - Parameter environment: The environment to read (defaults to the process
+  ///   environment). Injectable for testing.
+  /// - Throws: ``ResourcePrincipalError`` when the version is missing/unsupported
+  ///   or required values are absent.
+  public static func fromEnvironment(
+    _ environment: [String: String] = ProcessInfo.processInfo.environment
+  ) throws -> ResourcePrincipalSigner {
+    guard let version = environment[ResourcePrincipalEnv.version], !version.isEmpty else {
+      throw ResourcePrincipalError.versionNotDefined
+    }
+    guard version == ResourcePrincipalEnv.supportedVersion else {
+      throw ResourcePrincipalError.unsupportedVersion(version)
+    }
+    guard let rpstRaw = environment[ResourcePrincipalEnv.rpst], !rpstRaw.isEmpty else {
+      throw ResourcePrincipalError.missingSessionToken
+    }
+    guard let pemRaw = environment[ResourcePrincipalEnv.privatePem], !pemRaw.isEmpty else {
+      throw ResourcePrincipalError.missingPrivateKey
+    }
+
+    let signer = ResourcePrincipalSigner(
+      rpstSource: .detect(rpstRaw),
+      keySource: .detect(pemRaw),
+      region: environment[ResourcePrincipalEnv.region]
+    )
+    // Fail fast if the injected material is invalid, rather than at first request.
+    try signer.forceRefresh()
+    return signer
+  }
+
+  /// Builds a signer from an in-memory RPST and PEM private key (no file access).
+  ///
+  /// - Parameters:
+  ///   - sessionToken: The raw RPST value.
+  ///   - privateKeyPEM: The private key in PEM format.
+  ///   - region: Optional region id.
+  public convenience init(sessionToken: String, privateKeyPEM: String, region: String? = nil) {
+    self.init(rpstSource: .value(sessionToken), keySource: .pem(privateKeyPEM), region: region)
+  }
+
+  // MARK: Signer
+
+  public func sign(_ req: inout URLRequest) throws {
+    let (token, key) = try current()
+    try SecurityTokenSigner(securityToken: token, privateKey: key).sign(&req)
+  }
+
+  // MARK: Refresh
+
+  /// Forces a reload of the RPST and private key from their sources, regardless
+  /// of the cached token's remaining lifetime. Call this after receiving a `401`.
+  public func forceRefresh() throws {
+    lock.lock()
+    defer { lock.unlock() }
+    try refreshLocked()
+  }
+
+  /// Returns a currently-valid token/key pair, refreshing if the cache is empty
+  /// or the cached token is within the expiry jitter of its `exp`.
+  private func current() throws -> (String, _RSA.Signing.PrivateKey) {
+    lock.lock()
+    defer { lock.unlock() }
+
+    if let token = cachedToken, let key = cachedKey {
+      if let exp = cachedExpiry {
+        let now = Int(Date().timeIntervalSince1970)
+        if now <= exp - Self.expiryJitterSeconds {
+          return (token, key)
+        }
+        // Token is within the jitter window — fall through and refresh.
+      } else {
+        // No exp claim to evaluate; keep the cached material.
+        return (token, key)
+      }
+    }
+
+    try refreshLocked()
+    return (cachedToken!, cachedKey!)
+  }
+
+  /// Reloads token + key from their sources. Caller must hold `lock`.
+  private func refreshLocked() throws {
+    let token = try rpstSource.resolve().trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !token.isEmpty else { throw ResourcePrincipalError.missingSessionToken }
+
+    let pem = try keySource.resolve()
+    guard let key = try? _RSA.Signing.PrivateKey(pemRepresentation: pem) else {
+      throw ResourcePrincipalError.invalidPrivateKey
+    }
+
+    cachedToken = token
+    cachedKey = key
+    cachedExpiry = ResourcePrincipalToken.expiry(of: token)
+  }
+}
+
+// MARK: - Convenience source for in-memory PEM
+
+extension ResourcePrincipalSource {
+  /// A literal PEM value. Alias for `.value` that reads clearly at call sites.
+  static func pem(_ pem: String) -> ResourcePrincipalSource { .value(pem) }
+}
+
+// MARK: - RPST JWT parsing (no signature verification)
+
+/// Minimal RPST (JWT) reader. The RPST is a signed JWT, but — exactly like the
+/// Python SDK — the SDK only needs the `exp` claim and does **not** verify the
+/// signature (no key is required to read claims).
+enum ResourcePrincipalToken {
+  /// Returns the `exp` claim (epoch seconds) from a JWT, or `nil` if absent/unparseable.
+  static func expiry(of token: String) -> Int? {
+    let parts = token.split(separator: ".")
+    guard parts.count >= 2,
+      let payload = base64URLDecode(String(parts[1])),
+      let object = (try? JSONSerialization.jsonObject(with: payload)) as? [String: Any]
+    else {
+      return nil
+    }
+    if let exp = object["exp"] as? Int { return exp }
+    if let exp = object["exp"] as? Double { return Int(exp) }
+    return nil
+  }
+
+  /// Decodes a base64url segment (JWT payloads use base64url without padding).
+  static func base64URLDecode(_ string: String) -> Data? {
+    var base64 =
+      string
+      .replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+    let remainder = base64.count % 4
+    if remainder > 0 {
+      base64 += String(repeating: "=", count: 4 - remainder)
+    }
+    return Data(base64Encoded: base64)
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/ContainerInstances.swift
+++ b/Sources/OCIKit/services/ContainerInstances/ContainerInstances.swift
@@ -1,0 +1,459 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// Client for the OCI Container Instances service.
+///
+/// Container Instances lets you run containers directly on OCI-managed compute
+/// without provisioning or managing servers. This client creates and manages
+/// container instances, their containers, shapes, and the work requests that
+/// track asynchronous operations.
+///
+/// A common use is to launch a container that authenticates back to OCI using
+/// ``ResourcePrincipalSigner`` (Resource Principals v2.2), which OCI wires into
+/// the container's environment automatically.
+///
+/// ## Example
+/// ```swift
+/// let signer = try APIKeySigner(configFilePath: "~/.oci/config")
+/// let client = try ContainerInstancesClient(region: .fra, signer: signer)
+///
+/// let details = CreateContainerInstanceDetails(
+///   compartmentId: compartmentId,
+///   availabilityDomain: "AD-1",
+///   shape: "CI.Standard.E4.Flex",
+///   shapeConfig: CreateContainerInstanceShapeConfigDetails(ocpus: 1, memoryInGBs: 4),
+///   containers: [CreateContainerDetails(imageUrl: "hello-world")],
+///   vnics: [CreateContainerVnicDetails(subnetId: subnetId)]
+/// )
+/// let instance = try await client.createContainerInstance(createContainerInstanceDetails: details)
+/// ```
+public struct ContainerInstancesClient: Sendable {
+  let endpoint: URL?
+  let region: Region?
+  let retryConfig: RetryConfig?
+  let signer: Signer
+  let logger: Logger
+
+  // MARK: - Initialization
+
+  /// Initializes the Container Instances client.
+  ///
+  /// - Parameters:
+  ///   - region: A region used to determine the service endpoint.
+  ///   - endpoint: A fully-qualified endpoint URL. Takes precedence over `region`.
+  ///   - signer: A signer used to authenticate requests.
+  ///   - retryConfig: Optional retry configuration.
+  ///   - logger: Optional logger.
+  /// - Throws: ``ContainerInstancesError/missingRequiredParameter(_:)`` if neither
+  ///   `region` nor `endpoint` is provided.
+  public init(
+    region: Region? = nil,
+    endpoint: String? = nil,
+    signer: Signer,
+    retryConfig: RetryConfig? = nil,
+    logger: Logger = Logger(label: "ContainerInstancesClient")
+  ) throws {
+    self.signer = signer
+    self.retryConfig = retryConfig
+    self.logger = logger
+
+    if let endpoint, let endpointURL = URL(string: endpoint) {
+      self.endpoint = endpointURL
+      self.region = nil
+    }
+    else {
+      guard let region else {
+        throw ContainerInstancesError.missingRequiredParameter("Either endpoint or region must be specified.")
+      }
+      self.region = region
+      let host = Service.containerinstances.getHost(in: region)
+      self.endpoint = URL(string: "https://\(host)")
+    }
+  }
+
+  // MARK: - Container instances
+
+  /// Creates a new container instance. Returns the newly-created (provisioning)
+  /// instance; poll ``getContainerInstance(containerInstanceId:opcRequestId:)``
+  /// until its `lifecycleState` is `.active`.
+  public func createContainerInstance(
+    createContainerInstanceDetails: CreateContainerInstanceDetails,
+    opcRetryToken: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> ContainerInstance {
+    let body = try encode(createContainerInstanceDetails, op: "createContainerInstance")
+    let (data, _) = try await execute(
+      .createContainerInstance(opcRetryToken: opcRetryToken, opcRequestId: opcRequestId),
+      body: body,
+      expectedStatus: 200
+    )
+    return try decode(ContainerInstance.self, from: data, op: "createContainerInstance")
+  }
+
+  /// Gets a container instance by OCID.
+  public func getContainerInstance(
+    containerInstanceId: String,
+    opcRequestId: String? = nil
+  ) async throws -> ContainerInstance {
+    let (data, _) = try await execute(
+      .getContainerInstance(containerInstanceId: containerInstanceId, opcRequestId: opcRequestId),
+      expectedStatus: 200
+    )
+    return try decode(ContainerInstance.self, from: data, op: "getContainerInstance")
+  }
+
+  /// Lists the container instances in a compartment.
+  public func listContainerInstances(
+    compartmentId: String,
+    lifecycleState: ContainerInstanceLifecycleState? = nil,
+    displayName: String? = nil,
+    availabilityDomain: String? = nil,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: ContainerInstanceSortBy? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> ContainerInstanceCollection {
+    let (data, _) = try await execute(
+      .listContainerInstances(
+        compartmentId: compartmentId, lifecycleState: lifecycleState, displayName: displayName,
+        availabilityDomain: availabilityDomain, limit: limit, page: page, sortOrder: sortOrder,
+        sortBy: sortBy, opcRequestId: opcRequestId),
+      expectedStatus: 200
+    )
+    return try decode(ContainerInstanceCollection.self, from: data, op: "listContainerInstances")
+  }
+
+  /// Updates the mutable fields of a container instance. Returns the
+  /// `opc-work-request-id` for the asynchronous operation.
+  @discardableResult
+  public func updateContainerInstance(
+    containerInstanceId: String,
+    updateContainerInstanceDetails: UpdateContainerInstanceDetails,
+    ifMatch: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> String? {
+    let body = try encode(updateContainerInstanceDetails, op: "updateContainerInstance")
+    let (_, http) = try await execute(
+      .updateContainerInstance(containerInstanceId: containerInstanceId, ifMatch: ifMatch, opcRequestId: opcRequestId),
+      body: body,
+      expectedStatus: 202
+    )
+    return http.value(forHTTPHeaderField: "opc-work-request-id")
+  }
+
+  /// Deletes a container instance. Returns the `opc-work-request-id`.
+  @discardableResult
+  public func deleteContainerInstance(
+    containerInstanceId: String,
+    ifMatch: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> String? {
+    let (_, http) = try await execute(
+      .deleteContainerInstance(containerInstanceId: containerInstanceId, ifMatch: ifMatch, opcRequestId: opcRequestId),
+      expectedStatus: 202
+    )
+    return http.value(forHTTPHeaderField: "opc-work-request-id")
+  }
+
+  /// Moves a container instance to a different compartment. Returns the `opc-work-request-id`.
+  @discardableResult
+  public func changeContainerInstanceCompartment(
+    containerInstanceId: String,
+    changeContainerInstanceCompartmentDetails: ChangeContainerInstanceCompartmentDetails,
+    ifMatch: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> String? {
+    let body = try encode(changeContainerInstanceCompartmentDetails, op: "changeContainerInstanceCompartment")
+    let (_, http) = try await execute(
+      .changeContainerInstanceCompartment(containerInstanceId: containerInstanceId, ifMatch: ifMatch, opcRequestId: opcRequestId),
+      body: body,
+      expectedStatus: 202
+    )
+    return http.value(forHTTPHeaderField: "opc-work-request-id")
+  }
+
+  /// Starts a stopped container instance. Returns the `opc-work-request-id`.
+  @discardableResult
+  public func startContainerInstance(
+    containerInstanceId: String,
+    ifMatch: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> String? {
+    let (_, http) = try await execute(
+      .startContainerInstance(containerInstanceId: containerInstanceId, ifMatch: ifMatch, opcRequestId: opcRequestId),
+      expectedStatus: 202
+    )
+    return http.value(forHTTPHeaderField: "opc-work-request-id")
+  }
+
+  /// Stops a running container instance. Returns the `opc-work-request-id`.
+  @discardableResult
+  public func stopContainerInstance(
+    containerInstanceId: String,
+    ifMatch: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> String? {
+    let (_, http) = try await execute(
+      .stopContainerInstance(containerInstanceId: containerInstanceId, ifMatch: ifMatch, opcRequestId: opcRequestId),
+      expectedStatus: 202
+    )
+    return http.value(forHTTPHeaderField: "opc-work-request-id")
+  }
+
+  /// Restarts a container instance. Returns the `opc-work-request-id`.
+  @discardableResult
+  public func restartContainerInstance(
+    containerInstanceId: String,
+    ifMatch: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> String? {
+    let (_, http) = try await execute(
+      .restartContainerInstance(containerInstanceId: containerInstanceId, ifMatch: ifMatch, opcRequestId: opcRequestId),
+      expectedStatus: 202
+    )
+    return http.value(forHTTPHeaderField: "opc-work-request-id")
+  }
+
+  // MARK: - Shapes
+
+  /// Lists the available container instance shapes in a compartment.
+  public func listContainerInstanceShapes(
+    compartmentId: String,
+    availabilityDomain: String? = nil,
+    limit: Int? = nil,
+    page: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> ContainerInstanceShapeCollection {
+    let (data, _) = try await execute(
+      .listContainerInstanceShapes(
+        compartmentId: compartmentId, availabilityDomain: availabilityDomain, limit: limit, page: page,
+        opcRequestId: opcRequestId),
+      expectedStatus: 200
+    )
+    return try decode(ContainerInstanceShapeCollection.self, from: data, op: "listContainerInstanceShapes")
+  }
+
+  // MARK: - Containers
+
+  /// Gets a container by OCID.
+  public func getContainer(containerId: String, opcRequestId: String? = nil) async throws -> Container {
+    let (data, _) = try await execute(
+      .getContainer(containerId: containerId, opcRequestId: opcRequestId),
+      expectedStatus: 200
+    )
+    return try decode(Container.self, from: data, op: "getContainer")
+  }
+
+  /// Lists the containers in a compartment.
+  public func listContainers(
+    compartmentId: String,
+    lifecycleState: ContainerInstanceLifecycleState? = nil,
+    displayName: String? = nil,
+    containerInstanceId: String? = nil,
+    availabilityDomain: String? = nil,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: ContainerInstanceSortBy? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> ContainerCollection {
+    let (data, _) = try await execute(
+      .listContainers(
+        compartmentId: compartmentId, lifecycleState: lifecycleState, displayName: displayName,
+        containerInstanceId: containerInstanceId, availabilityDomain: availabilityDomain, limit: limit,
+        page: page, sortOrder: sortOrder, sortBy: sortBy, opcRequestId: opcRequestId),
+      expectedStatus: 200
+    )
+    return try decode(ContainerCollection.self, from: data, op: "listContainers")
+  }
+
+  /// Updates the mutable fields of a container. Returns the `opc-work-request-id`.
+  @discardableResult
+  public func updateContainer(
+    containerId: String,
+    updateContainerDetails: UpdateContainerDetails,
+    ifMatch: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> String? {
+    let body = try encode(updateContainerDetails, op: "updateContainer")
+    let (_, http) = try await execute(
+      .updateContainer(containerId: containerId, ifMatch: ifMatch, opcRequestId: opcRequestId),
+      body: body,
+      expectedStatus: 202
+    )
+    return http.value(forHTTPHeaderField: "opc-work-request-id")
+  }
+
+  /// Retrieves the most recent logs (up to 256 KB) emitted by a container.
+  ///
+  /// - Parameter isPrevious: When `true`, returns the logs of the previous run of
+  ///   a restarted container instead of the current run.
+  /// - Returns: The raw log text.
+  public func retrieveLogs(
+    containerId: String,
+    isPrevious: Bool? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> String {
+    guard let endpoint else {
+      throw ContainerInstancesError.missingRequiredParameter("No endpoint has been set")
+    }
+    var req = try buildRequest(
+      api: ContainerInstancesAPI.retrieveLogs(containerId: containerId, isPrevious: isPrevious, opcRequestId: opcRequestId),
+      endpoint: endpoint
+    )
+    // Logs are returned as text, not JSON.
+    req.setValue("application/json, text/plain", forHTTPHeaderField: "accept")
+    try signer.sign(&req)
+
+    let (data, response) = try await URLSession.shared.data(for: req)
+    guard let http = response as? HTTPURLResponse else {
+      throw ContainerInstancesError.invalidResponse("Invalid HTTP response")
+    }
+    guard http.statusCode == 200 else {
+      throw ContainerInstancesError.unexpectedStatusCode(http.statusCode, Self.errorMessage(from: data))
+    }
+    return String(data: data, encoding: .utf8) ?? ""
+  }
+
+  // MARK: - Work requests
+
+  /// Gets a work request by OCID.
+  public func getWorkRequest(workRequestId: String, opcRequestId: String? = nil) async throws -> ContainerInstanceWorkRequest {
+    let (data, _) = try await execute(
+      .getWorkRequest(workRequestId: workRequestId, opcRequestId: opcRequestId),
+      expectedStatus: 200
+    )
+    return try decode(ContainerInstanceWorkRequest.self, from: data, op: "getWorkRequest")
+  }
+
+  /// Lists the work requests in a compartment.
+  public func listWorkRequests(
+    compartmentId: String,
+    workRequestId: String? = nil,
+    resourceId: String? = nil,
+    availabilityDomain: String? = nil,
+    status: ContainerInstanceWorkRequestStatus? = nil,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> ContainerInstanceWorkRequestSummaryCollection {
+    let (data, _) = try await execute(
+      .listWorkRequests(
+        compartmentId: compartmentId, workRequestId: workRequestId, resourceId: resourceId,
+        availabilityDomain: availabilityDomain, status: status, limit: limit, page: page,
+        sortOrder: sortOrder, sortBy: sortBy, opcRequestId: opcRequestId),
+      expectedStatus: 200
+    )
+    return try decode(ContainerInstanceWorkRequestSummaryCollection.self, from: data, op: "listWorkRequests")
+  }
+
+  /// Lists the errors for a work request.
+  public func listWorkRequestErrors(
+    workRequestId: String,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> ContainerInstanceWorkRequestErrorCollection {
+    let (data, _) = try await execute(
+      .listWorkRequestErrors(
+        workRequestId: workRequestId, limit: limit, page: page, sortOrder: sortOrder, sortBy: sortBy,
+        opcRequestId: opcRequestId),
+      expectedStatus: 200
+    )
+    return try decode(ContainerInstanceWorkRequestErrorCollection.self, from: data, op: "listWorkRequestErrors")
+  }
+
+  /// Lists the logs for a work request.
+  public func listWorkRequestLogs(
+    workRequestId: String,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: String? = nil,
+    opcRequestId: String? = nil
+  ) async throws -> ContainerInstanceWorkRequestLogEntryCollection {
+    let (data, _) = try await execute(
+      .listWorkRequestLogs(
+        workRequestId: workRequestId, limit: limit, page: page, sortOrder: sortOrder, sortBy: sortBy,
+        opcRequestId: opcRequestId),
+      expectedStatus: 200
+    )
+    return try decode(ContainerInstanceWorkRequestLogEntryCollection.self, from: data, op: "listWorkRequestLogs")
+  }
+
+  // MARK: - Private helpers
+
+  /// Builds, signs, and executes a request, validating the HTTP status code.
+  private func execute(
+    _ api: ContainerInstancesAPI,
+    body: Data? = nil,
+    expectedStatus: Int
+  ) async throws -> (Data, HTTPURLResponse) {
+    guard let endpoint else {
+      throw ContainerInstancesError.missingRequiredParameter("No endpoint has been set")
+    }
+    var req = try buildRequest(api: api, endpoint: endpoint)
+    if let body { req.httpBody = body }
+    try signer.sign(&req)
+
+    let (data, response) = try await URLSession.shared.data(for: req)
+    guard let http = response as? HTTPURLResponse else {
+      throw ContainerInstancesError.invalidResponse("Invalid HTTP response")
+    }
+    guard http.statusCode == expectedStatus else {
+      let message = Self.errorMessage(from: data)
+      logger.error("[ContainerInstances] HTTP \(http.statusCode): \(message)")
+      throw ContainerInstancesError.unexpectedStatusCode(http.statusCode, message)
+    }
+    return (data, http)
+  }
+
+  private func encode<T: Encodable>(_ value: T, op: String) throws -> Data {
+    do {
+      return try JSONEncoder().encode(value)
+    }
+    catch {
+      throw ContainerInstancesError.jsonEncodingError("Failed to encode \(T.self) in \(op): \(error)")
+    }
+  }
+
+  private func decode<T: Decodable>(_ type: T.Type, from data: Data, op: String) throws -> T {
+    do {
+      return try JSONDecoder().decode(T.self, from: data)
+    }
+    catch {
+      throw ContainerInstancesError.jsonDecodingError("Failed to decode \(T.self) in \(op): \(error)")
+    }
+  }
+
+  /// Extracts a human-readable message from an OCI error body, falling back to raw text.
+  private static func errorMessage(from data: Data) -> String {
+    if let body = try? JSONDecoder().decode(DataBody.self, from: data) {
+      return body.message
+    }
+    return String(data: data, encoding: .utf8) ?? ""
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/ContainerInstances.swift
+++ b/Sources/OCIKit/services/ContainerInstances/ContainerInstances.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/ContainerInstancesRouter.swift
+++ b/Sources/OCIKit/services/ContainerInstances/ContainerInstancesRouter.swift
@@ -1,0 +1,303 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// API routes for the OCI Container Instances service (API version `20210415`).
+///
+/// Use Container Instances to run containers directly on OCI without managing
+/// any servers. See the
+/// [Container Instances documentation](https://docs.oracle.com/en-us/iaas/Content/container-instances/home.htm).
+public enum ContainerInstancesAPI: API {
+  /// The service API version path segment shared by every route.
+  static let version = "/20210415"
+
+  // MARK: Container instances
+
+  /// Creates a new container instance.
+  case createContainerInstance(opcRetryToken: String? = nil, opcRequestId: String? = nil)
+  /// Gets a single container instance by OCID.
+  case getContainerInstance(containerInstanceId: String, opcRequestId: String? = nil)
+  /// Lists the container instances in a compartment.
+  case listContainerInstances(
+    compartmentId: String,
+    lifecycleState: ContainerInstanceLifecycleState? = nil,
+    displayName: String? = nil,
+    availabilityDomain: String? = nil,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: ContainerInstanceSortBy? = nil,
+    opcRequestId: String? = nil
+  )
+  /// Updates the mutable fields of a container instance.
+  case updateContainerInstance(containerInstanceId: String, ifMatch: String? = nil, opcRequestId: String? = nil)
+  /// Deletes a container instance and its containers.
+  case deleteContainerInstance(containerInstanceId: String, ifMatch: String? = nil, opcRequestId: String? = nil)
+  /// Moves a container instance to a different compartment.
+  case changeContainerInstanceCompartment(containerInstanceId: String, ifMatch: String? = nil, opcRequestId: String? = nil)
+  /// Starts a previously-stopped container instance.
+  case startContainerInstance(containerInstanceId: String, ifMatch: String? = nil, opcRequestId: String? = nil)
+  /// Stops a running container instance.
+  case stopContainerInstance(containerInstanceId: String, ifMatch: String? = nil, opcRequestId: String? = nil)
+  /// Restarts a container instance.
+  case restartContainerInstance(containerInstanceId: String, ifMatch: String? = nil, opcRequestId: String? = nil)
+
+  // MARK: Shapes
+
+  /// Lists the available container instance shapes in a compartment.
+  case listContainerInstanceShapes(
+    compartmentId: String,
+    availabilityDomain: String? = nil,
+    limit: Int? = nil,
+    page: String? = nil,
+    opcRequestId: String? = nil
+  )
+
+  // MARK: Containers
+
+  /// Gets a single container by OCID.
+  case getContainer(containerId: String, opcRequestId: String? = nil)
+  /// Lists the containers in a compartment.
+  case listContainers(
+    compartmentId: String,
+    lifecycleState: ContainerInstanceLifecycleState? = nil,
+    displayName: String? = nil,
+    containerInstanceId: String? = nil,
+    availabilityDomain: String? = nil,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: ContainerInstanceSortBy? = nil,
+    opcRequestId: String? = nil
+  )
+  /// Updates the mutable fields of a container.
+  case updateContainer(containerId: String, ifMatch: String? = nil, opcRequestId: String? = nil)
+  /// Retrieves the most recent logs (up to 256 KB) emitted by a container.
+  case retrieveLogs(containerId: String, isPrevious: Bool? = nil, opcRequestId: String? = nil)
+
+  // MARK: Work requests
+
+  /// Gets the status of a work request.
+  case getWorkRequest(workRequestId: String, opcRequestId: String? = nil)
+  /// Lists the work requests in a compartment.
+  case listWorkRequests(
+    compartmentId: String,
+    workRequestId: String? = nil,
+    resourceId: String? = nil,
+    availabilityDomain: String? = nil,
+    status: ContainerInstanceWorkRequestStatus? = nil,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: String? = nil,
+    opcRequestId: String? = nil
+  )
+  /// Lists the errors for a work request.
+  case listWorkRequestErrors(
+    workRequestId: String,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: String? = nil,
+    opcRequestId: String? = nil
+  )
+  /// Lists the logs for a work request.
+  case listWorkRequestLogs(
+    workRequestId: String,
+    limit: Int? = nil,
+    page: String? = nil,
+    sortOrder: SortOrder? = nil,
+    sortBy: String? = nil,
+    opcRequestId: String? = nil
+  )
+
+  // MARK: - Path
+
+  public var path: String {
+    let v = Self.version
+    switch self {
+    case .createContainerInstance, .listContainerInstances:
+      return "\(v)/containerInstances"
+    case .getContainerInstance(let id, _),
+      .updateContainerInstance(let id, _, _),
+      .deleteContainerInstance(let id, _, _):
+      return "\(v)/containerInstances/\(id)"
+    case .changeContainerInstanceCompartment(let id, _, _):
+      return "\(v)/containerInstances/\(id)/actions/changeCompartment"
+    case .startContainerInstance(let id, _, _):
+      return "\(v)/containerInstances/\(id)/actions/start"
+    case .stopContainerInstance(let id, _, _):
+      return "\(v)/containerInstances/\(id)/actions/stop"
+    case .restartContainerInstance(let id, _, _):
+      return "\(v)/containerInstances/\(id)/actions/restart"
+    case .listContainerInstanceShapes:
+      return "\(v)/containerInstanceShapes"
+    case .getContainer(let id, _),
+      .updateContainer(let id, _, _):
+      return "\(v)/containers/\(id)"
+    case .listContainers:
+      return "\(v)/containers"
+    case .retrieveLogs(let id, _, _):
+      return "\(v)/containers/\(id)/actions/retrieveLogs"
+    case .getWorkRequest(let id, _):
+      return "\(v)/workRequests/\(id)"
+    case .listWorkRequests:
+      return "\(v)/workRequests"
+    case .listWorkRequestErrors(let id, _, _, _, _, _):
+      return "\(v)/workRequests/\(id)/errors"
+    case .listWorkRequestLogs(let id, _, _, _, _, _):
+      return "\(v)/workRequests/\(id)/logs"
+    }
+  }
+
+  // MARK: - HTTP Method
+
+  public var method: HTTPMethod {
+    switch self {
+    case .getContainerInstance,
+      .listContainerInstances,
+      .listContainerInstanceShapes,
+      .getContainer,
+      .listContainers,
+      .getWorkRequest,
+      .listWorkRequests,
+      .listWorkRequestErrors,
+      .listWorkRequestLogs:
+      return .get
+    case .createContainerInstance,
+      .changeContainerInstanceCompartment,
+      .startContainerInstance,
+      .stopContainerInstance,
+      .restartContainerInstance,
+      .retrieveLogs:
+      return .post
+    case .updateContainerInstance,
+      .updateContainer:
+      return .put
+    case .deleteContainerInstance:
+      return .delete
+    }
+  }
+
+  // MARK: - Query Items
+
+  public var queryItems: [URLQueryItem]? {
+    let pairs: [(String, String?)]
+    switch self {
+    case .listContainerInstances(
+      let compartmentId, let lifecycleState, let displayName, let availabilityDomain,
+      let limit, let page, let sortOrder, let sortBy, _):
+      pairs = [
+        ("compartmentId", compartmentId),
+        ("lifecycleState", lifecycleState?.rawValue),
+        ("displayName", displayName),
+        ("availabilityDomain", availabilityDomain),
+        ("limit", limit.map(String.init)),
+        ("page", page),
+        ("sortOrder", sortOrder?.rawValue),
+        ("sortBy", sortBy?.rawValue),
+      ]
+    case .listContainers(
+      let compartmentId, let lifecycleState, let displayName, let containerInstanceId,
+      let availabilityDomain, let limit, let page, let sortOrder, let sortBy, _):
+      pairs = [
+        ("compartmentId", compartmentId),
+        ("lifecycleState", lifecycleState?.rawValue),
+        ("displayName", displayName),
+        ("containerInstanceId", containerInstanceId),
+        ("availabilityDomain", availabilityDomain),
+        ("limit", limit.map(String.init)),
+        ("page", page),
+        ("sortOrder", sortOrder?.rawValue),
+        ("sortBy", sortBy?.rawValue),
+      ]
+    case .listContainerInstanceShapes(let compartmentId, let availabilityDomain, let limit, let page, _):
+      pairs = [
+        ("compartmentId", compartmentId),
+        ("availabilityDomain", availabilityDomain),
+        ("limit", limit.map(String.init)),
+        ("page", page),
+      ]
+    case .retrieveLogs(_, let isPrevious, _):
+      pairs = [("isPrevious", isPrevious.map { $0 ? "true" : "false" })]
+    case .listWorkRequests(
+      let compartmentId, let workRequestId, let resourceId, let availabilityDomain,
+      let status, let limit, let page, let sortOrder, let sortBy, _):
+      pairs = [
+        ("compartmentId", compartmentId),
+        ("workRequestId", workRequestId),
+        ("resourceId", resourceId),
+        ("availabilityDomain", availabilityDomain),
+        ("status", status?.rawValue),
+        ("limit", limit.map(String.init)),
+        ("page", page),
+        ("sortOrder", sortOrder?.rawValue),
+        ("sortBy", sortBy),
+      ]
+    case .listWorkRequestErrors(_, let limit, let page, let sortOrder, let sortBy, _),
+      .listWorkRequestLogs(_, let limit, let page, let sortOrder, let sortBy, _):
+      pairs = [
+        ("limit", limit.map(String.init)),
+        ("page", page),
+        ("sortOrder", sortOrder?.rawValue),
+        ("sortBy", sortBy),
+      ]
+    default:
+      return nil
+    }
+
+    let items = pairs.compactMap { key, value in
+      value.map { URLQueryItem(name: key, value: $0) }
+    }
+    return items.isEmpty ? nil : items
+  }
+
+  // MARK: - Headers
+
+  public var headers: [String: String]? {
+    var headers: [String: String] = [:]
+    switch self {
+    case .createContainerInstance(let opcRetryToken, let opcRequestId):
+      if let opcRetryToken { headers["opc-retry-token"] = opcRetryToken }
+      if let opcRequestId { headers["opc-request-id"] = opcRequestId }
+    case .getContainerInstance(_, let opcRequestId),
+      .getContainer(_, let opcRequestId),
+      .getWorkRequest(_, let opcRequestId):
+      if let opcRequestId { headers["opc-request-id"] = opcRequestId }
+    case .updateContainerInstance(_, let ifMatch, let opcRequestId),
+      .deleteContainerInstance(_, let ifMatch, let opcRequestId),
+      .changeContainerInstanceCompartment(_, let ifMatch, let opcRequestId),
+      .startContainerInstance(_, let ifMatch, let opcRequestId),
+      .stopContainerInstance(_, let ifMatch, let opcRequestId),
+      .restartContainerInstance(_, let ifMatch, let opcRequestId),
+      .updateContainer(_, let ifMatch, let opcRequestId):
+      if let ifMatch { headers["if-match"] = ifMatch }
+      if let opcRequestId { headers["opc-request-id"] = opcRequestId }
+    case .listContainerInstances(_, _, _, _, _, _, _, _, let opcRequestId),
+      .listContainers(_, _, _, _, _, _, _, _, _, let opcRequestId),
+      .listContainerInstanceShapes(_, _, _, _, let opcRequestId),
+      .retrieveLogs(_, _, let opcRequestId),
+      .listWorkRequests(_, _, _, _, _, _, _, _, _, let opcRequestId),
+      .listWorkRequestErrors(_, _, _, _, _, let opcRequestId),
+      .listWorkRequestLogs(_, _, _, _, _, let opcRequestId):
+      if let opcRequestId { headers["opc-request-id"] = opcRequestId }
+    }
+    return headers.isEmpty ? nil : headers
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/ContainerInstancesRouter.swift
+++ b/Sources/OCIKit/services/ContainerInstances/ContainerInstancesRouter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ChangeContainerInstanceCompartmentDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ChangeContainerInstanceCompartmentDetails.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The configuration details for the move operation.
+public struct ChangeContainerInstanceCompartmentDetails: Codable {
+  /// The OCID of the compartment to move the container instance to.
+  public let compartmentId: String
+
+  public init(compartmentId: String) {
+    self.compartmentId = compartmentId
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ChangeContainerInstanceCompartmentDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ChangeContainerInstanceCompartmentDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/Container.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/Container.swift
@@ -1,0 +1,174 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A single container on a container instance.
+///
+/// If you delete a container, the record remains visible for a short period
+/// of time before being permanently removed.
+public struct Container: Codable {
+  /// The OCID of the container.
+  public let id: String
+  /// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+  public let displayName: String
+  /// The OCID of the compartment that contains the container.
+  public let compartmentId: String
+  /// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+  public let freeformTags: [String: String]?
+  /// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+  public let definedTags: [String: [String: String]]?
+  /// Usage of system tag keys. These predefined keys are scoped to namespaces.
+  public let systemTags: [String: [String: String]]?
+  /// The availability domain where the container instance that hosts the container runs.
+  public let availabilityDomain: String
+  /// The fault domain of the container instance that hosts the container runs.
+  public let faultDomain: String?
+  /// The current state of the container.
+  public let lifecycleState: ContainerInstanceLifecycleState
+  /// A message that describes the current state of the container in more detail. Can be used to provide actionable information.
+  public let lifecycleDetails: String?
+  /// The exit code of the container process when it stopped running.
+  public let exitCode: Int?
+  /// The time when the container last deleted (terminated), as a raw RFC3339 string.
+  private let timeTerminatedRaw: String?
+  /// The time when the container last deleted (terminated).
+  public var timeTerminated: Date? {
+    guard let raw = timeTerminatedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The time the container was created, as a raw RFC3339 string.
+  private let timeCreatedRaw: String?
+  /// The time the container was created.
+  public var timeCreated: Date? {
+    guard let raw = timeCreatedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The time the container was updated, as a raw RFC3339 string.
+  private let timeUpdatedRaw: String?
+  /// The time the container was updated.
+  public var timeUpdated: Date? {
+    guard let raw = timeUpdatedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The OCID of the container instance that the container is running on.
+  public let containerInstanceId: String
+  /// The container image information. Currently only supports public Docker registry.
+  public let imageUrl: String
+  /// This command overrides ENTRYPOINT process of the container.
+  public let command: [String]?
+  /// A list of string arguments for the ENTRYPOINT process of the container.
+  public let arguments: [String]?
+  /// The working directory within the container's filesystem for the container process.
+  public let workingDirectory: String?
+  /// A map of additional environment variables to set in the environment of the ENTRYPOINT process of the container.
+  public let environmentVariables: [String: String]?
+  /// List of the volume mounts.
+  public let volumeMounts: [VolumeMount]?
+  /// List of container health checks.
+  public let healthChecks: [ContainerHealthCheck]?
+  /// Determines if the container will have access to the container instance resource principal.
+  public let isResourcePrincipalDisabled: Bool?
+  /// The resource configuration for the container.
+  public let resourceConfig: ContainerResourceConfig?
+  /// The number of container restart attempts. Depending on the restart policy, a restart might be attempted after a health check failure or a container exit.
+  public let containerRestartAttemptCount: Int?
+  /// The security context of the container.
+  public let securityContext: SecurityContext?
+
+  public init(
+    id: String,
+    displayName: String,
+    compartmentId: String,
+    freeformTags: [String: String]? = nil,
+    definedTags: [String: [String: String]]? = nil,
+    systemTags: [String: [String: String]]? = nil,
+    availabilityDomain: String,
+    faultDomain: String? = nil,
+    lifecycleState: ContainerInstanceLifecycleState,
+    lifecycleDetails: String? = nil,
+    exitCode: Int? = nil,
+    timeTerminatedRaw: String? = nil,
+    timeCreatedRaw: String? = nil,
+    timeUpdatedRaw: String? = nil,
+    containerInstanceId: String,
+    imageUrl: String,
+    command: [String]? = nil,
+    arguments: [String]? = nil,
+    workingDirectory: String? = nil,
+    environmentVariables: [String: String]? = nil,
+    volumeMounts: [VolumeMount]? = nil,
+    healthChecks: [ContainerHealthCheck]? = nil,
+    isResourcePrincipalDisabled: Bool? = nil,
+    resourceConfig: ContainerResourceConfig? = nil,
+    containerRestartAttemptCount: Int? = nil,
+    securityContext: SecurityContext? = nil
+  ) {
+    self.id = id
+    self.displayName = displayName
+    self.compartmentId = compartmentId
+    self.freeformTags = freeformTags
+    self.definedTags = definedTags
+    self.systemTags = systemTags
+    self.availabilityDomain = availabilityDomain
+    self.faultDomain = faultDomain
+    self.lifecycleState = lifecycleState
+    self.lifecycleDetails = lifecycleDetails
+    self.exitCode = exitCode
+    self.timeTerminatedRaw = timeTerminatedRaw
+    self.timeCreatedRaw = timeCreatedRaw
+    self.timeUpdatedRaw = timeUpdatedRaw
+    self.containerInstanceId = containerInstanceId
+    self.imageUrl = imageUrl
+    self.command = command
+    self.arguments = arguments
+    self.workingDirectory = workingDirectory
+    self.environmentVariables = environmentVariables
+    self.volumeMounts = volumeMounts
+    self.healthChecks = healthChecks
+    self.isResourcePrincipalDisabled = isResourcePrincipalDisabled
+    self.resourceConfig = resourceConfig
+    self.containerRestartAttemptCount = containerRestartAttemptCount
+    self.securityContext = securityContext
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case displayName
+    case compartmentId
+    case freeformTags
+    case definedTags
+    case systemTags
+    case availabilityDomain
+    case faultDomain
+    case lifecycleState
+    case lifecycleDetails
+    case exitCode
+    case timeTerminatedRaw = "timeTerminated"
+    case timeCreatedRaw = "timeCreated"
+    case timeUpdatedRaw = "timeUpdated"
+    case containerInstanceId
+    case imageUrl
+    case command
+    case arguments
+    case workingDirectory
+    case environmentVariables
+    case volumeMounts
+    case healthChecks
+    case isResourcePrincipalDisabled
+    case resourceConfig
+    case containerRestartAttemptCount
+    case securityContext
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/Container.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/Container.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerCapabilities.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerCapabilities.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Linux Container capabilities to configure capabilities of container.
+public struct ContainerCapabilities: Codable {
+  /// A list of additional configurable container capabilities.
+  public let addCapabilities: [String]?
+  /// A list of container capabilities that can be dropped.
+  public let dropCapabilities: [String]?
+
+  public init(addCapabilities: [String]? = nil, dropCapabilities: [String]? = nil) {
+    self.addCapabilities = addCapabilities
+    self.dropCapabilities = dropCapabilities
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerCapabilities.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerCapabilities.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerCollection.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A list of containers.
+public struct ContainerCollection: Codable {
+  /// List of containers.
+  public let items: [ContainerSummary]
+
+  public init(items: [ContainerSummary]) {
+    self.items = items
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerConfigFile.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerConfigFile.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The file that is mounted on a container instance through a volume mount.
+public struct ContainerConfigFile: Codable {
+  /// The name of the file. The fileName should be unique across the volume.
+  public let fileName: String
+  /// The base64 encoded contents of the file. The contents are decoded to plain text before mounted as a file to a container inside container instance.
+  public let data: String
+  /// (Optional) Relative path for this file inside the volume mount directory. By default, the file is presented at the root of the volume mount path.
+  public let path: String?
+
+  public init(fileName: String, data: String, path: String? = nil) {
+    self.fileName = fileName
+    self.data = data
+    self.path = path
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerConfigFile.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerConfigFile.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerDnsConfig.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerDnsConfig.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// DNS settings for containers.
+public struct ContainerDnsConfig: Codable {
+  /// IP address of the name server.
+  public let nameservers: [String]?
+  /// Search list for hostname lookup.
+  public let searches: [String]?
+  /// Options allows certain internal resolver variables to be modified.
+  public let options: [String]?
+
+  public init(nameservers: [String]? = nil, searches: [String]? = nil, options: [String]? = nil) {
+    self.nameservers = nameservers
+    self.searches = searches
+    self.options = options
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerDnsConfig.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerDnsConfig.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerHealthCheck.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerHealthCheck.swift
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Type of container health check, which could be either HTTP or TCP.
+///
+/// This is a flattened union of the HTTP and TCP health check subtypes. The
+/// `healthCheckType` discriminator selects which subtype-specific fields apply.
+/// Prefer the `http(...)` and `tcp(...)` factory methods over the memberwise
+/// initializer.
+public struct ContainerHealthCheck: Codable {
+  /// Health check name.
+  public let name: String?
+  /// Container health check type.
+  public let healthCheckType: ContainerHealthCheckType
+  /// The initial delay in seconds before start checking container health status.
+  public let initialDelayInSeconds: Int?
+  /// Number of seconds between two consecutive runs for checking container health.
+  public let intervalInSeconds: Int?
+  /// Number of consecutive failures at which we consider the check failed.
+  public let failureThreshold: Int?
+  /// Number of consecutive successes at which we consider the check succeeded again after it was in failure state.
+  public let successThreshold: Int?
+  /// Length of waiting time in seconds before marking health check failed.
+  public let timeoutInSeconds: Int?
+  /// Status of the container.
+  public let status: ContainerHealthCheckStatus?
+  /// A message describing the current status in more detail.
+  public let statusDetails: String?
+  /// The action triggered when the container health check fails. There are two types of action: KILL or NONE.
+  /// The default action is KILL. If the failure action is KILL, the container is subject to the container restart policy.
+  public let failureAction: ContainerHealthCheckFailureAction?
+  /// (HTTP only) Container health check HTTP path.
+  public let path: String?
+  /// (HTTP/TCP only) Container health check port.
+  public let port: Int?
+  /// (HTTP only) Container health check HTTP headers.
+  public let headers: [HealthCheckHttpHeader]?
+
+  public init(
+    name: String? = nil,
+    healthCheckType: ContainerHealthCheckType,
+    initialDelayInSeconds: Int? = nil,
+    intervalInSeconds: Int? = nil,
+    failureThreshold: Int? = nil,
+    successThreshold: Int? = nil,
+    timeoutInSeconds: Int? = nil,
+    status: ContainerHealthCheckStatus? = nil,
+    statusDetails: String? = nil,
+    failureAction: ContainerHealthCheckFailureAction? = nil,
+    path: String? = nil,
+    port: Int? = nil,
+    headers: [HealthCheckHttpHeader]? = nil
+  ) {
+    self.name = name
+    self.healthCheckType = healthCheckType
+    self.initialDelayInSeconds = initialDelayInSeconds
+    self.intervalInSeconds = intervalInSeconds
+    self.failureThreshold = failureThreshold
+    self.successThreshold = successThreshold
+    self.timeoutInSeconds = timeoutInSeconds
+    self.status = status
+    self.statusDetails = statusDetails
+    self.failureAction = failureAction
+    self.path = path
+    self.port = port
+    self.headers = headers
+  }
+
+  /// Creates an HTTP container health check.
+  public static func http(
+    path: String,
+    port: Int,
+    name: String? = nil,
+    initialDelayInSeconds: Int? = nil,
+    intervalInSeconds: Int? = nil,
+    failureThreshold: Int? = nil,
+    successThreshold: Int? = nil,
+    timeoutInSeconds: Int? = nil,
+    status: ContainerHealthCheckStatus? = nil,
+    statusDetails: String? = nil,
+    failureAction: ContainerHealthCheckFailureAction? = nil,
+    headers: [HealthCheckHttpHeader]? = nil
+  ) -> ContainerHealthCheck {
+    ContainerHealthCheck(
+      name: name,
+      healthCheckType: .http,
+      initialDelayInSeconds: initialDelayInSeconds,
+      intervalInSeconds: intervalInSeconds,
+      failureThreshold: failureThreshold,
+      successThreshold: successThreshold,
+      timeoutInSeconds: timeoutInSeconds,
+      status: status,
+      statusDetails: statusDetails,
+      failureAction: failureAction,
+      path: path,
+      port: port,
+      headers: headers
+    )
+  }
+
+  /// Creates a TCP container health check.
+  public static func tcp(
+    port: Int,
+    name: String? = nil,
+    initialDelayInSeconds: Int? = nil,
+    intervalInSeconds: Int? = nil,
+    failureThreshold: Int? = nil,
+    successThreshold: Int? = nil,
+    timeoutInSeconds: Int? = nil,
+    status: ContainerHealthCheckStatus? = nil,
+    statusDetails: String? = nil,
+    failureAction: ContainerHealthCheckFailureAction? = nil
+  ) -> ContainerHealthCheck {
+    ContainerHealthCheck(
+      name: name,
+      healthCheckType: .tcp,
+      initialDelayInSeconds: initialDelayInSeconds,
+      intervalInSeconds: intervalInSeconds,
+      failureThreshold: failureThreshold,
+      successThreshold: successThreshold,
+      timeoutInSeconds: timeoutInSeconds,
+      status: status,
+      statusDetails: statusDetails,
+      failureAction: failureAction,
+      port: port
+    )
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerHealthCheck.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerHealthCheck.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstance.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstance.swift
@@ -1,0 +1,164 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A container instance to host containers.
+///
+/// If you delete a container instance, the record remains visible for a short period
+/// of time before being permanently removed.
+public struct ContainerInstance: Codable {
+  /// An OCID that cannot be changed.
+  public let id: String
+  /// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+  public let displayName: String
+  /// The OCID of the compartment.
+  public let compartmentId: String
+  /// TenantId id of the container instance.
+  public let tenantId: String?
+  /// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+  public let freeformTags: [String: String]?
+  /// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+  public let definedTags: [String: [String: String]]?
+  /// Usage of system tag keys. These predefined keys are scoped to namespaces.
+  public let systemTags: [String: [String: String]]?
+  /// The availability domain to place the container instance.
+  public let availabilityDomain: String
+  /// The fault domain to place the container instance.
+  public let faultDomain: String?
+  /// The current state of the container instance.
+  public let lifecycleState: ContainerInstanceLifecycleState
+  /// A message that describes the current state of the container in more detail. Can be used to provide actionable information.
+  public let lifecycleDetails: String?
+  /// A volume is a directory with data that is accessible across multiple containers in a container instance.
+  public let volumes: [ContainerVolume]?
+  /// The number of volumes that are attached to the container instance.
+  public let volumeCount: Int?
+  /// The containers on the container instance.
+  public let containers: [ContainerInstanceContainer]
+  /// The number of containers on the container instance.
+  public let containerCount: Int
+  /// The time the container instance was created, as a raw RFC3339 string.
+  private let timeCreatedRaw: String?
+  /// The time the container instance was created.
+  public var timeCreated: Date? {
+    guard let raw = timeCreatedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The time the container instance was updated, as a raw RFC3339 string.
+  private let timeUpdatedRaw: String?
+  /// The time the container instance was updated.
+  public var timeUpdated: Date? {
+    guard let raw = timeUpdatedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The shape of the container instance. The shape determines the number of OCPUs, amount of memory, and other resources that are allocated to a container instance.
+  public let shape: String
+  /// The shape configuration for the container instance.
+  public let shapeConfig: ContainerInstanceShapeConfig
+  /// The virtual networks available to the containers in the container instance.
+  public let vnics: [ContainerVnic]
+  /// The DNS configuration for the container instance.
+  public let dnsConfig: ContainerDnsConfig?
+  /// The amount of time that processes in a container have to gracefully end when the container must be stopped. For example, when you delete a container instance. After the timeout is reached, the processes are sent a signal to be deleted.
+  public let gracefulShutdownTimeoutInSeconds: Int?
+  /// The image pulls secrets so you can access private registry to pull container images.
+  public let imagePullSecrets: [ImagePullSecret]?
+  /// The container restart policy is applied for all containers in container instance.
+  public let containerRestartPolicy: ContainerRestartPolicy
+  /// The security context for the container instance.
+  public let securityContext: ContainerInstanceSecurityContext?
+
+  public init(
+    id: String,
+    displayName: String,
+    compartmentId: String,
+    tenantId: String? = nil,
+    freeformTags: [String: String]? = nil,
+    definedTags: [String: [String: String]]? = nil,
+    systemTags: [String: [String: String]]? = nil,
+    availabilityDomain: String,
+    faultDomain: String? = nil,
+    lifecycleState: ContainerInstanceLifecycleState,
+    lifecycleDetails: String? = nil,
+    volumes: [ContainerVolume]? = nil,
+    volumeCount: Int? = nil,
+    containers: [ContainerInstanceContainer],
+    containerCount: Int,
+    timeCreatedRaw: String? = nil,
+    timeUpdatedRaw: String? = nil,
+    shape: String,
+    shapeConfig: ContainerInstanceShapeConfig,
+    vnics: [ContainerVnic],
+    dnsConfig: ContainerDnsConfig? = nil,
+    gracefulShutdownTimeoutInSeconds: Int? = nil,
+    imagePullSecrets: [ImagePullSecret]? = nil,
+    containerRestartPolicy: ContainerRestartPolicy,
+    securityContext: ContainerInstanceSecurityContext? = nil
+  ) {
+    self.id = id
+    self.displayName = displayName
+    self.compartmentId = compartmentId
+    self.tenantId = tenantId
+    self.freeformTags = freeformTags
+    self.definedTags = definedTags
+    self.systemTags = systemTags
+    self.availabilityDomain = availabilityDomain
+    self.faultDomain = faultDomain
+    self.lifecycleState = lifecycleState
+    self.lifecycleDetails = lifecycleDetails
+    self.volumes = volumes
+    self.volumeCount = volumeCount
+    self.containers = containers
+    self.containerCount = containerCount
+    self.timeCreatedRaw = timeCreatedRaw
+    self.timeUpdatedRaw = timeUpdatedRaw
+    self.shape = shape
+    self.shapeConfig = shapeConfig
+    self.vnics = vnics
+    self.dnsConfig = dnsConfig
+    self.gracefulShutdownTimeoutInSeconds = gracefulShutdownTimeoutInSeconds
+    self.imagePullSecrets = imagePullSecrets
+    self.containerRestartPolicy = containerRestartPolicy
+    self.securityContext = securityContext
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case displayName
+    case compartmentId
+    case tenantId
+    case freeformTags
+    case definedTags
+    case systemTags
+    case availabilityDomain
+    case faultDomain
+    case lifecycleState
+    case lifecycleDetails
+    case volumes
+    case volumeCount
+    case containers
+    case containerCount
+    case timeCreatedRaw = "timeCreated"
+    case timeUpdatedRaw = "timeUpdated"
+    case shape
+    case shapeConfig
+    case vnics
+    case dnsConfig
+    case gracefulShutdownTimeoutInSeconds
+    case imagePullSecrets
+    case containerRestartPolicy
+    case securityContext
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstance.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstance.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceCollection.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Summary information about a list of container instances.
+public struct ContainerInstanceCollection: Codable {
+  /// List of container instances.
+  public let items: [ContainerInstanceSummary]
+
+  public init(items: [ContainerInstanceSummary]) {
+    self.items = items
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceContainer.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceContainer.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A container on a container instance.
+public struct ContainerInstanceContainer: Codable {
+  /// The OCID of the container.
+  public let containerId: String
+  /// Display name for the Container.
+  public let displayName: String?
+
+  public init(
+    containerId: String,
+    displayName: String? = nil
+  ) {
+    self.containerId = containerId
+    self.displayName = displayName
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceContainer.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceContainer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceSecurityContext.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceSecurityContext.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Security context for all containers in a container instance.
+public struct ContainerInstanceSecurityContext: Codable {
+  /// The type of security context.
+  public let securityContextType: SecurityContextType
+  /// (LINUX only) A special supplemental group that applies to all containers in the container instance.
+  /// Some volume types allow the container instance to change ownership of the volume. The owning GID will
+  /// be the fsGroup, the setgid bit will be set (new files will be owned by the fsGroup), and the permission
+  /// bits are OR'd with rw-rw----. If unset, the container instance will not modify the ownership and
+  /// permissions of volumes.
+  public let fsGroup: Int?
+  /// (LINUX only) Defines behavior of changing ownership and permission of the volume before being exposed
+  /// inside the containers.
+  public let fsGroupChangePolicy: FsGroupChangePolicy?
+
+  public init(
+    securityContextType: SecurityContextType,
+    fsGroup: Int? = nil,
+    fsGroupChangePolicy: FsGroupChangePolicy? = nil
+  ) {
+    self.securityContextType = securityContextType
+    self.fsGroup = fsGroup
+    self.fsGroupChangePolicy = fsGroupChangePolicy
+  }
+
+  /// Creates a security context for all containers in a Linux container instance.
+  public static func linux(
+    fsGroup: Int? = nil,
+    fsGroupChangePolicy: FsGroupChangePolicy? = nil
+  ) -> ContainerInstanceSecurityContext {
+    ContainerInstanceSecurityContext(
+      securityContextType: .linux,
+      fsGroup: fsGroup,
+      fsGroupChangePolicy: fsGroupChangePolicy
+    )
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceSecurityContext.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceSecurityContext.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeCollection.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A collection of container instance shapes.
+public struct ContainerInstanceShapeCollection: Codable {
+  /// A list of shapes.
+  public let items: [ContainerInstanceShapeSummary]
+
+  public init(items: [ContainerInstanceShapeSummary]) {
+    self.items = items
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeConfig.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeConfig.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The shape configuration for a container instance. The shape configuration determines
+/// the resources thats are available to the container instance and its containers.
+public struct ContainerInstanceShapeConfig: Codable {
+  /// The total number of OCPUs available to the container instance.
+  public let ocpus: Float
+  /// The total amount of memory available to the container instance, in gigabytes.
+  public let memoryInGBs: Float
+  /// A short description of the container instance's processor (CPU).
+  public let processorDescription: String
+  /// The networking bandwidth available to the container instance, in gigabits per second.
+  public let networkingBandwidthInGbps: Float
+
+  public init(
+    ocpus: Float,
+    memoryInGBs: Float,
+    processorDescription: String,
+    networkingBandwidthInGbps: Float
+  ) {
+    self.ocpus = ocpus
+    self.memoryInGBs = memoryInGBs
+    self.processorDescription = processorDescription
+    self.networkingBandwidthInGbps = networkingBandwidthInGbps
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeConfig.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeConfig.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeSummary.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeSummary.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Details about a shape for a container instance.
+public struct ContainerInstanceShapeSummary: Codable {
+  /// The name identifying the shape.
+  public let name: String
+  /// A short description of the container instance's processor (CPU).
+  public let processorDescription: String
+  /// For a flexible shape, the number of OCPUs available for container instances that use this shape.
+  public let ocpuOptions: ShapeOcpuOptions?
+  /// For a flexible shape, the amount of memory available for container instances that use this shape.
+  public let memoryOptions: ShapeMemoryOptions?
+  /// For a flexible shape, the amount of networking bandwidth available for container instances that use this shape.
+  public let networkingBandwidthOptions: ShapeNetworkingBandwidthOptions?
+
+  public init(
+    name: String,
+    processorDescription: String,
+    ocpuOptions: ShapeOcpuOptions? = nil,
+    memoryOptions: ShapeMemoryOptions? = nil,
+    networkingBandwidthOptions: ShapeNetworkingBandwidthOptions? = nil
+  ) {
+    self.name = name
+    self.processorDescription = processorDescription
+    self.ocpuOptions = ocpuOptions
+    self.memoryOptions = memoryOptions
+    self.networkingBandwidthOptions = networkingBandwidthOptions
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeSummary.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceShapeSummary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceSummary.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceSummary.swift
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A set of details about a single container instance returned by list APIs.
+public struct ContainerInstanceSummary: Codable {
+  /// OCID that cannot be changed.
+  public let id: String
+  /// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+  public let displayName: String
+  /// The OCID of the compartment to create the container instance in.
+  public let compartmentId: String
+  /// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+  public let freeformTags: [String: String]?
+  /// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+  public let definedTags: [String: [String: String]]?
+  /// Usage of system tag keys. These predefined keys are scoped to namespaces.
+  public let systemTags: [String: [String: String]]?
+  /// The availability domain where the container instance runs.
+  public let availabilityDomain: String
+  /// The fault domain where the container instance runs.
+  public let faultDomain: String?
+  /// The current state of the container instance.
+  public let lifecycleState: ContainerInstanceLifecycleState
+  /// A message that describes the current state of the container instance in more detail. Can be used to provide actionable information.
+  public let lifecycleDetails: String?
+  /// The time the container instance was created, as a raw RFC3339 string.
+  private let timeCreatedRaw: String?
+  /// The time the container instance was created.
+  public var timeCreated: Date? {
+    guard let raw = timeCreatedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The time the container instance was updated, as a raw RFC3339 string.
+  private let timeUpdatedRaw: String?
+  /// The time the container instance was updated.
+  public var timeUpdated: Date? {
+    guard let raw = timeUpdatedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The shape of the container instance. The shape determines the resources available to the container instance.
+  public let shape: String
+  /// The shape configuration for the container instance.
+  public let shapeConfig: ContainerInstanceShapeConfig
+  /// The number of containers in the container instance.
+  public let containerCount: Int
+  /// The amount of time that processes in a container have to gracefully end when the container must be stopped. For example, when you delete a container instance. After the timeout is reached, the processes are sent a signal to be deleted.
+  public let gracefulShutdownTimeoutInSeconds: Int?
+  /// The number of volumes that are attached to the container instance.
+  public let volumeCount: Int?
+  /// Container Restart Policy.
+  public let containerRestartPolicy: ContainerRestartPolicy
+  /// The security context for the container instance.
+  public let securityContext: ContainerInstanceSecurityContext?
+
+  public init(
+    id: String,
+    displayName: String,
+    compartmentId: String,
+    freeformTags: [String: String]? = nil,
+    definedTags: [String: [String: String]]? = nil,
+    systemTags: [String: [String: String]]? = nil,
+    availabilityDomain: String,
+    faultDomain: String? = nil,
+    lifecycleState: ContainerInstanceLifecycleState,
+    lifecycleDetails: String? = nil,
+    timeCreatedRaw: String? = nil,
+    timeUpdatedRaw: String? = nil,
+    shape: String,
+    shapeConfig: ContainerInstanceShapeConfig,
+    containerCount: Int,
+    gracefulShutdownTimeoutInSeconds: Int? = nil,
+    volumeCount: Int? = nil,
+    containerRestartPolicy: ContainerRestartPolicy,
+    securityContext: ContainerInstanceSecurityContext? = nil
+  ) {
+    self.id = id
+    self.displayName = displayName
+    self.compartmentId = compartmentId
+    self.freeformTags = freeformTags
+    self.definedTags = definedTags
+    self.systemTags = systemTags
+    self.availabilityDomain = availabilityDomain
+    self.faultDomain = faultDomain
+    self.lifecycleState = lifecycleState
+    self.lifecycleDetails = lifecycleDetails
+    self.timeCreatedRaw = timeCreatedRaw
+    self.timeUpdatedRaw = timeUpdatedRaw
+    self.shape = shape
+    self.shapeConfig = shapeConfig
+    self.containerCount = containerCount
+    self.gracefulShutdownTimeoutInSeconds = gracefulShutdownTimeoutInSeconds
+    self.volumeCount = volumeCount
+    self.containerRestartPolicy = containerRestartPolicy
+    self.securityContext = securityContext
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case displayName
+    case compartmentId
+    case freeformTags
+    case definedTags
+    case systemTags
+    case availabilityDomain
+    case faultDomain
+    case lifecycleState
+    case lifecycleDetails
+    case timeCreatedRaw = "timeCreated"
+    case timeUpdatedRaw = "timeUpdated"
+    case shape
+    case shapeConfig
+    case containerCount
+    case gracefulShutdownTimeoutInSeconds
+    case volumeCount
+    case containerRestartPolicy
+    case securityContext
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceSummary.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceSummary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequest.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequest.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A description of the work request status.
+public struct ContainerInstanceWorkRequest: Codable {
+  /// Type of work request.
+  public let operationType: ContainerInstanceWorkRequestOperationType
+  /// Status of current work request.
+  public let status: ContainerInstanceWorkRequestStatus
+  /// The ID of the work request.
+  public let id: String
+  /// The OCID of the compartment that contains the work request. Work requests should be scoped to
+  /// the same compartment as the resource the work request affects.
+  public let compartmentId: String
+  /// The resources affected by this work request.
+  public let resources: [ContainerInstanceWorkRequestResource]
+  /// Percentage of the request completed.
+  public let percentComplete: Float
+  /// The date and time the request was created, as a raw RFC3339 string.
+  private let timeAcceptedRaw: String
+  /// The date and time the request was created, as described in RFC 3339, section 14.29.
+  public var timeAccepted: Date? {
+    return Date.fromRFC3339(timeAcceptedRaw)
+  }
+  /// The date and time the request was started, as a raw RFC3339 string.
+  private let timeStartedRaw: String?
+  /// The date and time the request was started, as described in RFC 3339, section 14.29.
+  public var timeStarted: Date? {
+    guard let raw = timeStartedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The date and time the object was finished, as a raw RFC3339 string.
+  private let timeFinishedRaw: String?
+  /// The date and time the object was finished, as described in RFC 3339.
+  public var timeFinished: Date? {
+    guard let raw = timeFinishedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+
+  public init(
+    operationType: ContainerInstanceWorkRequestOperationType,
+    status: ContainerInstanceWorkRequestStatus,
+    id: String,
+    compartmentId: String,
+    resources: [ContainerInstanceWorkRequestResource],
+    percentComplete: Float,
+    timeAcceptedRaw: String,
+    timeStartedRaw: String? = nil,
+    timeFinishedRaw: String? = nil
+  ) {
+    self.operationType = operationType
+    self.status = status
+    self.id = id
+    self.compartmentId = compartmentId
+    self.resources = resources
+    self.percentComplete = percentComplete
+    self.timeAcceptedRaw = timeAcceptedRaw
+    self.timeStartedRaw = timeStartedRaw
+    self.timeFinishedRaw = timeFinishedRaw
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case operationType
+    case status
+    case id
+    case compartmentId
+    case resources
+    case percentComplete
+    case timeAcceptedRaw = "timeAccepted"
+    case timeStartedRaw = "timeStarted"
+    case timeFinishedRaw = "timeFinished"
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequest.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestError.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestError.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// An error encountered while executing a work request.
+public struct ContainerInstanceWorkRequestError: Codable {
+  /// A machine-usable code for the error that occured. See API Errors for a list of error codes.
+  public let code: String
+  /// A description of the issue encountered.
+  public let message: String
+  /// The time the error occured, as a raw RFC3339 string.
+  private let timestampRaw: String
+  /// The time the error occured, in the format defined by RFC 3339.
+  public var timestamp: Date? {
+    return Date.fromRFC3339(timestampRaw)
+  }
+
+  public init(
+    code: String,
+    message: String,
+    timestampRaw: String
+  ) {
+    self.code = code
+    self.message = message
+    self.timestampRaw = timestampRaw
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case code
+    case message
+    case timestampRaw = "timestamp"
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestError.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestErrorCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestErrorCollection.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Results of a workRequestError search. Contains both WorkRequestError items and other information, such as metadata.
+public struct ContainerInstanceWorkRequestErrorCollection: Codable {
+  /// List of workRequestError objects.
+  public let items: [ContainerInstanceWorkRequestError]
+
+  public init(items: [ContainerInstanceWorkRequestError]) {
+    self.items = items
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestErrorCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestErrorCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestLogEntry.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestLogEntry.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A log message from a work request.
+public struct ContainerInstanceWorkRequestLogEntry: Codable {
+  /// Human-readable log message.
+  public let message: String
+  /// The time the log message was written, as a raw RFC3339 string.
+  private let timestampRaw: String
+  /// The time the log message was written, in the format defined by RFC 3339.
+  public var timestamp: Date? {
+    return Date.fromRFC3339(timestampRaw)
+  }
+
+  public init(
+    message: String,
+    timestampRaw: String
+  ) {
+    self.message = message
+    self.timestampRaw = timestampRaw
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case message
+    case timestampRaw = "timestamp"
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestLogEntry.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestLogEntry.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestLogEntryCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestLogEntryCollection.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Results of a workRequestLog search. Contains both workRequestLog items and other information, such as metadata.
+public struct ContainerInstanceWorkRequestLogEntryCollection: Codable {
+  /// List of workRequestLogEntries.
+  public let items: [ContainerInstanceWorkRequestLogEntry]
+
+  public init(items: [ContainerInstanceWorkRequestLogEntry]) {
+    self.items = items
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestLogEntryCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestLogEntryCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestResource.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestResource.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A resource created or operated on by a work request.
+public struct ContainerInstanceWorkRequestResource: Codable {
+  /// The resource type the work request affects.
+  public let entityType: String
+  /// The way in which this resource is affected by the work tracked in the work request.
+  /// A resource being created, updated, or deleted remains in the IN_PROGRESS state until
+  /// work is complete for that resource, at which point it updates to CREATED, UPDATED,
+  /// or DELETED, respectively.
+  public let actionType: ContainerInstanceWorkRequestActionType
+  /// The ID of the resource the work request affects.
+  public let identifier: String
+  /// The URI path that the user can do a GET on to access the resource metadata.
+  public let entityUri: String?
+
+  public init(
+    entityType: String,
+    actionType: ContainerInstanceWorkRequestActionType,
+    identifier: String,
+    entityUri: String? = nil
+  ) {
+    self.entityType = entityType
+    self.actionType = actionType
+    self.identifier = identifier
+    self.entityUri = entityUri
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestResource.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestResource.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestSummary.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestSummary.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A summary of the status of a work request.
+public struct ContainerInstanceWorkRequestSummary: Codable {
+  /// Type of work request.
+  public let operationType: ContainerInstanceWorkRequestOperationType
+  /// Status of current work request.
+  public let status: ContainerInstanceWorkRequestStatus
+  /// The ID of the work request.
+  public let id: String
+  /// The OCID of the compartment that contains the work request. Work requests should be scoped to
+  /// the same compartment as the resource the work request affects.
+  public let compartmentId: String
+  /// The resources affected by this work request.
+  public let resources: [ContainerInstanceWorkRequestResource]
+  /// Percentage of the request completed.
+  public let percentComplete: Float
+  /// The date and time the request was created, as a raw RFC3339 string.
+  private let timeAcceptedRaw: String
+  /// The date and time the request was created, as described in RFC 3339, section 14.29.
+  public var timeAccepted: Date? {
+    return Date.fromRFC3339(timeAcceptedRaw)
+  }
+  /// The date and time the request was started, as a raw RFC3339 string.
+  private let timeStartedRaw: String?
+  /// The date and time the request was started, as described in RFC 3339, section 14.29.
+  public var timeStarted: Date? {
+    guard let raw = timeStartedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The date and time the object was finished, as a raw RFC3339 string.
+  private let timeFinishedRaw: String?
+  /// The date and time the object was finished, as described in RFC 3339.
+  public var timeFinished: Date? {
+    guard let raw = timeFinishedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+
+  public init(
+    operationType: ContainerInstanceWorkRequestOperationType,
+    status: ContainerInstanceWorkRequestStatus,
+    id: String,
+    compartmentId: String,
+    resources: [ContainerInstanceWorkRequestResource],
+    percentComplete: Float,
+    timeAcceptedRaw: String,
+    timeStartedRaw: String? = nil,
+    timeFinishedRaw: String? = nil
+  ) {
+    self.operationType = operationType
+    self.status = status
+    self.id = id
+    self.compartmentId = compartmentId
+    self.resources = resources
+    self.percentComplete = percentComplete
+    self.timeAcceptedRaw = timeAcceptedRaw
+    self.timeStartedRaw = timeStartedRaw
+    self.timeFinishedRaw = timeFinishedRaw
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case operationType
+    case status
+    case id
+    case compartmentId
+    case resources
+    case percentComplete
+    case timeAcceptedRaw = "timeAccepted"
+    case timeStartedRaw = "timeStarted"
+    case timeFinishedRaw = "timeFinished"
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestSummary.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestSummary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestSummaryCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestSummaryCollection.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Results of a workRequest search. Contains both WorkRequest items and other information, such as metadata.
+public struct ContainerInstanceWorkRequestSummaryCollection: Codable {
+  /// List of workRequestSummary objects.
+  public let items: [ContainerInstanceWorkRequestSummary]
+
+  public init(items: [ContainerInstanceWorkRequestSummary]) {
+    self.items = items
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestSummaryCollection.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstanceWorkRequestSummaryCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstancesEnums.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstancesEnums.swift
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+// MARK: - Lifecycle
+
+/// The lifecycle state of a container instance or container.
+///
+/// The same value domain is used by both `ContainerInstance`/`ContainerInstanceSummary`
+/// and `Container`/`ContainerSummary`.
+public enum ContainerInstanceLifecycleState: String, Codable, Sendable {
+  case creating = "CREATING"
+  case updating = "UPDATING"
+  case active = "ACTIVE"
+  case inactive = "INACTIVE"
+  case deleting = "DELETING"
+  case deleted = "DELETED"
+  case failed = "FAILED"
+}
+
+/// The restart policy applied to the containers of a container instance.
+public enum ContainerRestartPolicy: String, Codable, Sendable {
+  case always = "ALWAYS"
+  case never = "NEVER"
+  case onFailure = "ON_FAILURE"
+}
+
+// MARK: - Image pull secrets / volumes
+
+/// The type of an image pull secret used to authenticate to a container registry.
+public enum ImagePullSecretType: String, Codable, Sendable {
+  case basic = "BASIC"
+  case vault = "VAULT"
+}
+
+/// The type of a container volume.
+public enum ContainerVolumeType: String, Codable, Sendable {
+  case emptyDir = "EMPTYDIR"
+  case configFile = "CONFIGFILE"
+  case ociFssFileSystem = "OCI_FSS_FILE_SYSTEM"
+}
+
+// MARK: - Health checks
+
+/// The protocol/type of a container health check.
+public enum ContainerHealthCheckType: String, Codable, Sendable {
+  case http = "HTTP"
+  case tcp = "TCP"
+  case command = "COMMAND"
+}
+
+/// The action performed when a container health check fails.
+public enum ContainerHealthCheckFailureAction: String, Codable, Sendable {
+  case kill = "KILL"
+  case none = "NONE"
+}
+
+/// The observed health status of a container.
+public enum ContainerHealthCheckStatus: String, Codable, Sendable {
+  case unknown = "UNKNOWN"
+  case healthy = "HEALTHY"
+  case unhealthy = "UNHEALTHY"
+}
+
+// MARK: - Security context
+
+/// The type of a container / container-instance security context.
+public enum SecurityContextType: String, Codable, Sendable {
+  case linux = "LINUX"
+}
+
+// MARK: - Work requests
+
+/// The status of a container instances work request.
+public enum ContainerInstanceWorkRequestStatus: String, Codable, Sendable {
+  case accepted = "ACCEPTED"
+  case inProgress = "IN_PROGRESS"
+  case failed = "FAILED"
+  case succeeded = "SUCCEEDED"
+  case canceling = "CANCELING"
+  case canceled = "CANCELED"
+}
+
+/// The type of operation a container instances work request represents.
+public enum ContainerInstanceWorkRequestOperationType: String, Codable, Sendable {
+  case createContainerInstance = "CREATE_CONTAINER_INSTANCE"
+  case updateContainerInstance = "UPDATE_CONTAINER_INSTANCE"
+  case deleteContainerInstance = "DELETE_CONTAINER_INSTANCE"
+  case moveContainerInstance = "MOVE_CONTAINER_INSTANCE"
+  case startContainerInstance = "START_CONTAINER_INSTANCE"
+  case stopContainerInstance = "STOP_CONTAINER_INSTANCE"
+  case restartContainerInstance = "RESTART_CONTAINER_INSTANCE"
+  case updateContainer = "UPDATE_CONTAINER"
+}
+
+/// The effect a work request had on an affected resource.
+public enum ContainerInstanceWorkRequestActionType: String, Codable, Sendable {
+  case created = "CREATED"
+  case updated = "UPDATED"
+  case deleted = "DELETED"
+  case inProgress = "IN_PROGRESS"
+  case related = "RELATED"
+  case failed = "FAILED"
+}
+
+// MARK: - Sorting
+
+/// The field to sort container instances / containers by.
+public enum ContainerInstanceSortBy: String, Codable, Sendable {
+  case timeCreated
+  case displayName
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstancesEnums.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstancesEnums.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstancesErrors.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstancesErrors.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Errors thrown by ``ContainerInstancesClient``.
+///
+/// Log format: `[ContainerInstances function name]` error code (HTTPResponse.statusCode): error message.
+/// The service error body is decoded into the shared ``DataBody`` type.
+public enum ContainerInstancesError: Error {
+  case invalidResponse(String)
+  case invalidURL(String)
+  case jsonDecodingError(String)
+  case jsonEncodingError(String)
+  case missingRequiredParameter(String)
+  case unexpectedStatusCode(Int, String)
+}
+
+extension ContainerInstancesError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .invalidResponse(let response):
+      return "API returned an invalid response: \(response)"
+    case .invalidURL(let url):
+      return "Provided URL is invalid: \(url)"
+    case .jsonDecodingError(let errorString):
+      return "JSON decoding error: \(errorString)"
+    case .jsonEncodingError(let errorString):
+      return "JSON encoding error: \(errorString)"
+    case .missingRequiredParameter(let param):
+      return "Missing required parameter \(param)"
+    case .unexpectedStatusCode(let code, let message):
+      return "Error (\(code)): \(message)"
+    }
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstancesErrors.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerInstancesErrors.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerResourceConfig.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerResourceConfig.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The resource configuration for a container. The resource configuration determines
+/// the amount of resources allocated to the container and the maximum allowed resources for a container.
+public struct ContainerResourceConfig: Codable {
+  /// The maximum amount of CPUs that can be consumed by the container's process.
+  ///
+  /// If you do not set a value, then the process may use all available CPU resources on the container instance.
+  /// CPU usage is defined in terms of logical CPUs. This means that the maximum possible value on an E3
+  /// ContainerInstance with 1 OCPU is 2.0.
+  public let vcpusLimit: Float?
+  /// The maximum amount of memory that can be consumed by the container's process.
+  /// If you do not set a value, then the process may use all available memory on the instance.
+  public let memoryLimitInGBs: Float?
+
+  public init(vcpusLimit: Float? = nil, memoryLimitInGBs: Float? = nil) {
+    self.vcpusLimit = vcpusLimit
+    self.memoryLimitInGBs = memoryLimitInGBs
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerResourceConfig.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerResourceConfig.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerSummary.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerSummary.swift
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Summary information about a container.
+public struct ContainerSummary: Codable {
+  /// The OCID of the container.
+  public let id: String
+  /// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+  public let displayName: String
+  /// The compartment OCID.
+  public let compartmentId: String
+  /// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+  public let freeformTags: [String: String]?
+  /// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+  public let definedTags: [String: [String: String]]?
+  /// Usage of system tag keys. These predefined keys are scoped to namespaces.
+  public let systemTags: [String: [String: String]]?
+  /// The availability domain where the container instance that hosts this container runs.
+  public let availabilityDomain: String
+  /// The fault domain where the container instance that hosts the container runs.
+  public let faultDomain: String?
+  /// The current state of the container.
+  public let lifecycleState: ContainerInstanceLifecycleState
+  /// A message that describes the current state of the container in more detail. Can be used to provide actionable information.
+  public let lifecycleDetails: String?
+  /// The time the container was created, as a raw RFC3339 string.
+  private let timeCreatedRaw: String?
+  /// The time the container was created.
+  public var timeCreated: Date? {
+    guard let raw = timeCreatedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The time the container was updated, as a raw RFC3339 string.
+  private let timeUpdatedRaw: String?
+  /// The time the container was updated.
+  public var timeUpdated: Date? {
+    guard let raw = timeUpdatedRaw else { return nil }
+    return Date.fromRFC3339(raw)
+  }
+  /// The OCID of the container instance on which the container is running.
+  public let containerInstanceId: String
+  /// The resource configuration for the container.
+  public let resourceConfig: ContainerResourceConfig?
+  /// A URL identifying the image that the container runs in, such as docker.io/library/busybox:latest.
+  public let imageUrl: String
+  /// Determines whether the container will have access to the container instance resource principal.
+  public let isResourcePrincipalDisabled: Bool?
+  /// The security context of the container.
+  public let securityContext: SecurityContext?
+
+  public init(
+    id: String,
+    displayName: String,
+    compartmentId: String,
+    freeformTags: [String: String]? = nil,
+    definedTags: [String: [String: String]]? = nil,
+    systemTags: [String: [String: String]]? = nil,
+    availabilityDomain: String,
+    faultDomain: String? = nil,
+    lifecycleState: ContainerInstanceLifecycleState,
+    lifecycleDetails: String? = nil,
+    timeCreatedRaw: String? = nil,
+    timeUpdatedRaw: String? = nil,
+    containerInstanceId: String,
+    resourceConfig: ContainerResourceConfig? = nil,
+    imageUrl: String,
+    isResourcePrincipalDisabled: Bool? = nil,
+    securityContext: SecurityContext? = nil
+  ) {
+    self.id = id
+    self.displayName = displayName
+    self.compartmentId = compartmentId
+    self.freeformTags = freeformTags
+    self.definedTags = definedTags
+    self.systemTags = systemTags
+    self.availabilityDomain = availabilityDomain
+    self.faultDomain = faultDomain
+    self.lifecycleState = lifecycleState
+    self.lifecycleDetails = lifecycleDetails
+    self.timeCreatedRaw = timeCreatedRaw
+    self.timeUpdatedRaw = timeUpdatedRaw
+    self.containerInstanceId = containerInstanceId
+    self.resourceConfig = resourceConfig
+    self.imageUrl = imageUrl
+    self.isResourcePrincipalDisabled = isResourcePrincipalDisabled
+    self.securityContext = securityContext
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case displayName
+    case compartmentId
+    case freeformTags
+    case definedTags
+    case systemTags
+    case availabilityDomain
+    case faultDomain
+    case lifecycleState
+    case lifecycleDetails
+    case timeCreatedRaw = "timeCreated"
+    case timeUpdatedRaw = "timeUpdated"
+    case containerInstanceId
+    case resourceConfig
+    case imageUrl
+    case isResourcePrincipalDisabled
+    case securityContext
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerSummary.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerSummary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerVnic.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerVnic.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// An interface to a virtual network available to containers on a container instance.
+public struct ContainerVnic: Codable {
+  /// The identifier of the virtual network interface card (VNIC) over which
+  /// the containers accessing this network can communicate with the
+  /// larger virtual cloud network.
+  public let vnicId: String?
+
+  public init(vnicId: String? = nil) {
+    self.vnicId = vnicId
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerVnic.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerVnic.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerVolume.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerVolume.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A volume represents a directory with data that is accessible across multiple containers in a container instance.
+public struct ContainerVolume: Codable {
+  /// The name of the volume. This must be unique within a single container instance.
+  public let name: String
+  /// The type of volume.
+  public let volumeType: ContainerVolumeType
+  /// (EMPTYDIR only) The volume type of the empty directory, can be either File Storage or Memory.
+  public let backingStore: String?
+  /// (CONFIGFILE only) Contains string key value pairs which can be mounted as individual files inside the container. The value needs to be base64 encoded. It is decoded to plain text before the mount.
+  public let configs: [ContainerConfigFile]?
+
+  public init(name: String, volumeType: ContainerVolumeType, backingStore: String? = nil, configs: [ContainerConfigFile]? = nil) {
+    self.name = name
+    self.volumeType = volumeType
+    self.backingStore = backingStore
+    self.configs = configs
+  }
+
+  /// Creates an EMPTYDIR volume.
+  public static func emptyDir(name: String, backingStore: String? = nil) -> ContainerVolume {
+    ContainerVolume(name: name, volumeType: .emptyDir, backingStore: backingStore)
+  }
+
+  /// Creates a CONFIGFILE volume.
+  public static func configFile(name: String, configs: [ContainerConfigFile]) -> ContainerVolume {
+    ContainerVolume(name: name, volumeType: .configFile, configs: configs)
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ContainerVolume.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ContainerVolume.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerDetails.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Information to create a new container within a container instance.
+///
+/// The container created by this call contains both the tags specified in this object and any tags
+/// specified in the parent container instance. The container is created in the same compartment,
+/// availability domain, and fault domain as its container instance.
+public struct CreateContainerDetails: Codable {
+  /// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information. If you don't provide a name, a name is generated automatically.
+  public let displayName: String?
+  /// A URL identifying the image that the container runs in, such as docker.io/library/busybox:latest. If you do not provide a tag, the tag will default to latest. If no registry is provided, will default the registry to public docker hub `docker.io/library`. The registry used for container image must be reachable over the Container Instance's VNIC.
+  public let imageUrl: String
+  /// An optional command that overrides the ENTRYPOINT process. If you do not provide a value, the existing ENTRYPOINT process defined in the image is used.
+  public let command: [String]?
+  /// A list of string arguments for a container's ENTRYPOINT process. Many containers use an ENTRYPOINT process pointing to a shell (/bin/bash). For those containers, this argument list specifies the main command in the container process. The total size of all arguments combined must be 64 KB or smaller.
+  public let arguments: [String]?
+  /// The working directory within the container's filesystem for the container process. If not specified, the default working directory from the image is used.
+  public let workingDirectory: String?
+  /// A map of additional environment variables to set in the environment of the container's ENTRYPOINT process. These variables are in addition to any variables already defined in the container's image. The total size of all environment variables combined, name and values, must be 64 KB or smaller.
+  public let environmentVariables: [String: String]?
+  /// List of the volume mounts.
+  public let volumeMounts: [CreateVolumeMountDetails]?
+  /// Determines if the container will have access to the container instance resource principal. This method utilizes resource principal version 2.2.
+  public let isResourcePrincipalDisabled: Bool?
+  /// The size and amount of resources available to the container.
+  public let resourceConfig: CreateContainerResourceConfigDetails?
+  /// list of container health checks to check container status and take appropriate action if container status is failed. There are two types of health checks that we currently support HTTP and TCP.
+  public let healthChecks: [CreateContainerHealthCheckDetails]?
+  /// The security context to apply to the container.
+  public let securityContext: CreateSecurityContextDetails?
+  /// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only. Example: `{"bar-key": "value"}`
+  public let freeformTags: [String: String]?
+  /// Defined tags for this resource. Each key is predefined and scoped to a namespace. Example: `{"foo-namespace": {"bar-key": "value"}}`.
+  public let definedTags: [String: [String: String]]?
+
+  public init(
+    displayName: String? = nil,
+    imageUrl: String,
+    command: [String]? = nil,
+    arguments: [String]? = nil,
+    workingDirectory: String? = nil,
+    environmentVariables: [String: String]? = nil,
+    volumeMounts: [CreateVolumeMountDetails]? = nil,
+    isResourcePrincipalDisabled: Bool? = nil,
+    resourceConfig: CreateContainerResourceConfigDetails? = nil,
+    healthChecks: [CreateContainerHealthCheckDetails]? = nil,
+    securityContext: CreateSecurityContextDetails? = nil,
+    freeformTags: [String: String]? = nil,
+    definedTags: [String: [String: String]]? = nil
+  ) {
+    self.displayName = displayName
+    self.imageUrl = imageUrl
+    self.command = command
+    self.arguments = arguments
+    self.workingDirectory = workingDirectory
+    self.environmentVariables = environmentVariables
+    self.volumeMounts = volumeMounts
+    self.isResourcePrincipalDisabled = isResourcePrincipalDisabled
+    self.resourceConfig = resourceConfig
+    self.healthChecks = healthChecks
+    self.securityContext = securityContext
+    self.freeformTags = freeformTags
+    self.definedTags = definedTags
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerDnsConfigDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerDnsConfigDetails.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Allow customers to define DNS settings for containers. If this is not provided, the containers use the default DNS settings of the subnet.
+public struct CreateContainerDnsConfigDetails: Codable {
+  /// IP address of a name server that the resolver should query, either an IPv4 address (in dot notation), or an IPv6 address in colon (and possibly dot) notation. If null, uses nameservers from subnet dhcpDnsOptions.
+  public let nameservers: [String]?
+  /// Search list for host-name lookup. If null, uses searches from subnet dhcpDnsOptions.
+  public let searches: [String]?
+  /// Options allows certain internal resolver variables to be modified. Options are a list of objects in https://man7.org/linux/man-pages/man5/resolv.conf.5.html. Examples: ["ndots:n", "edns0"].
+  public let options: [String]?
+
+  public init(nameservers: [String]? = nil, searches: [String]? = nil, options: [String]? = nil) {
+    self.nameservers = nameservers
+    self.searches = searches
+    self.options = options
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerDnsConfigDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerDnsConfigDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerHealthCheckDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerHealthCheckDetails.swift
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Container health check used to check and report the status of a container.
+///
+/// This is a flattened union of the HTTP and TCP health check subtypes. The
+/// `healthCheckType` discriminator selects which subtype-specific fields apply.
+/// Prefer the `http(...)` and `tcp(...)` factory methods over the memberwise
+/// initializer.
+public struct CreateContainerHealthCheckDetails: Codable {
+  /// Health check name.
+  public let name: String?
+  /// Container health check type.
+  public let healthCheckType: ContainerHealthCheckType
+  /// The initial delay in seconds before start checking container health status.
+  public let initialDelayInSeconds: Int?
+  /// Number of seconds between two consecutive runs for checking container health.
+  public let intervalInSeconds: Int?
+  /// Number of consecutive failures at which we consider the check failed.
+  public let failureThreshold: Int?
+  /// Number of consecutive successes at which we consider the check succeeded again after it was in failure state.
+  public let successThreshold: Int?
+  /// Length of waiting time in seconds before marking health check failed.
+  public let timeoutInSeconds: Int?
+  /// The action triggered when the container health check fails. There are two types of action: KILL or NONE.
+  /// The default action is KILL. If the failure action is KILL, the container is subject to the container restart policy.
+  public let failureAction: ContainerHealthCheckFailureAction?
+  /// (HTTP only) Container health check HTTP path.
+  public let path: String?
+  /// (HTTP/TCP only) Container health check port.
+  public let port: Int?
+  /// (HTTP only) Container health check HTTP headers.
+  public let headers: [HealthCheckHttpHeader]?
+
+  public init(
+    name: String? = nil,
+    healthCheckType: ContainerHealthCheckType,
+    initialDelayInSeconds: Int? = nil,
+    intervalInSeconds: Int? = nil,
+    failureThreshold: Int? = nil,
+    successThreshold: Int? = nil,
+    timeoutInSeconds: Int? = nil,
+    failureAction: ContainerHealthCheckFailureAction? = nil,
+    path: String? = nil,
+    port: Int? = nil,
+    headers: [HealthCheckHttpHeader]? = nil
+  ) {
+    self.name = name
+    self.healthCheckType = healthCheckType
+    self.initialDelayInSeconds = initialDelayInSeconds
+    self.intervalInSeconds = intervalInSeconds
+    self.failureThreshold = failureThreshold
+    self.successThreshold = successThreshold
+    self.timeoutInSeconds = timeoutInSeconds
+    self.failureAction = failureAction
+    self.path = path
+    self.port = port
+    self.headers = headers
+  }
+
+  /// Creates an HTTP container health check.
+  public static func http(
+    path: String,
+    port: Int,
+    name: String? = nil,
+    initialDelayInSeconds: Int? = nil,
+    intervalInSeconds: Int? = nil,
+    failureThreshold: Int? = nil,
+    successThreshold: Int? = nil,
+    timeoutInSeconds: Int? = nil,
+    failureAction: ContainerHealthCheckFailureAction? = nil,
+    headers: [HealthCheckHttpHeader]? = nil
+  ) -> CreateContainerHealthCheckDetails {
+    CreateContainerHealthCheckDetails(
+      name: name,
+      healthCheckType: .http,
+      initialDelayInSeconds: initialDelayInSeconds,
+      intervalInSeconds: intervalInSeconds,
+      failureThreshold: failureThreshold,
+      successThreshold: successThreshold,
+      timeoutInSeconds: timeoutInSeconds,
+      failureAction: failureAction,
+      path: path,
+      port: port,
+      headers: headers
+    )
+  }
+
+  /// Creates a TCP container health check.
+  public static func tcp(
+    port: Int,
+    name: String? = nil,
+    initialDelayInSeconds: Int? = nil,
+    intervalInSeconds: Int? = nil,
+    failureThreshold: Int? = nil,
+    successThreshold: Int? = nil,
+    timeoutInSeconds: Int? = nil,
+    failureAction: ContainerHealthCheckFailureAction? = nil
+  ) -> CreateContainerHealthCheckDetails {
+    CreateContainerHealthCheckDetails(
+      name: name,
+      healthCheckType: .tcp,
+      initialDelayInSeconds: initialDelayInSeconds,
+      intervalInSeconds: intervalInSeconds,
+      failureThreshold: failureThreshold,
+      successThreshold: successThreshold,
+      timeoutInSeconds: timeoutInSeconds,
+      failureAction: failureAction,
+      port: port
+    )
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerHealthCheckDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerHealthCheckDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceDetails.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Information to create a container instance.
+public struct CreateContainerInstanceDetails: Codable {
+  /// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information. If you don't provide a name, a name is generated automatically.
+  public let displayName: String?
+  /// The compartment OCID.
+  public let compartmentId: String
+  /// The availability domain where the container instance runs.
+  public let availabilityDomain: String
+  /// The fault domain where the container instance runs.
+  public let faultDomain: String?
+  /// The shape of the container instance. The shape determines the resources available to the container instance.
+  public let shape: String
+  /// The size and amount of resources available to the container instance.
+  public let shapeConfig: CreateContainerInstanceShapeConfigDetails
+  /// A volume is a directory with data that is accessible across multiple containers in a container instance. You can attach up to 32 volumes to single container instance.
+  public let volumes: [CreateContainerVolumeDetails]?
+  /// The containers to create on this container instance.
+  public let containers: [CreateContainerDetails]
+  /// The networks available to containers on this container instance.
+  public let vnics: [CreateContainerVnicDetails]
+  /// The DNS configuration of the container instance.
+  public let dnsConfig: CreateContainerDnsConfigDetails?
+  /// The amount of time that processes in a container have to gracefully end when the container must be stopped. For example, when you delete a container instance. After the timeout is reached, the processes are sent a signal to be deleted.
+  public let gracefulShutdownTimeoutInSeconds: Int?
+  /// The image pulls secrets so you can access private registry to pull container images.
+  public let imagePullSecrets: [CreateImagePullSecretDetails]?
+  /// Container restart policy
+  public let containerRestartPolicy: ContainerRestartPolicy?
+  /// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only. Example: `{"bar-key": "value"}`
+  public let freeformTags: [String: String]?
+  /// Defined tags for this resource. Each key is predefined and scoped to a namespace. Example: `{"foo-namespace": {"bar-key": "value"}}`.
+  public let definedTags: [String: [String: String]]?
+  /// The security context to apply to the container instance.
+  public let securityContext: CreateContainerInstanceSecurityContextDetails?
+
+  public init(
+    displayName: String? = nil,
+    compartmentId: String,
+    availabilityDomain: String,
+    faultDomain: String? = nil,
+    shape: String,
+    shapeConfig: CreateContainerInstanceShapeConfigDetails,
+    volumes: [CreateContainerVolumeDetails]? = nil,
+    containers: [CreateContainerDetails],
+    vnics: [CreateContainerVnicDetails],
+    dnsConfig: CreateContainerDnsConfigDetails? = nil,
+    gracefulShutdownTimeoutInSeconds: Int? = nil,
+    imagePullSecrets: [CreateImagePullSecretDetails]? = nil,
+    containerRestartPolicy: ContainerRestartPolicy? = nil,
+    freeformTags: [String: String]? = nil,
+    definedTags: [String: [String: String]]? = nil,
+    securityContext: CreateContainerInstanceSecurityContextDetails? = nil
+  ) {
+    self.displayName = displayName
+    self.compartmentId = compartmentId
+    self.availabilityDomain = availabilityDomain
+    self.faultDomain = faultDomain
+    self.shape = shape
+    self.shapeConfig = shapeConfig
+    self.volumes = volumes
+    self.containers = containers
+    self.vnics = vnics
+    self.dnsConfig = dnsConfig
+    self.gracefulShutdownTimeoutInSeconds = gracefulShutdownTimeoutInSeconds
+    self.imagePullSecrets = imagePullSecrets
+    self.containerRestartPolicy = containerRestartPolicy
+    self.freeformTags = freeformTags
+    self.definedTags = definedTags
+    self.securityContext = securityContext
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceSecurityContextDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceSecurityContextDetails.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Security context for all containers in a container instance.
+public struct CreateContainerInstanceSecurityContextDetails: Codable {
+  /// The type of security context.
+  public let securityContextType: SecurityContextType
+  /// (LINUX only) A special supplemental group that applies to all containers in the container instance.
+  /// Some volume types allow the container instance to change ownership of the volume. The owning GID will
+  /// be the fsGroup, the setgid bit will be set (new files will be owned by the fsGroup), and the permission
+  /// bits are OR'd with rw-rw----. If unset, the container instance will not modify the ownership and
+  /// permissions of volumes.
+  public let fsGroup: Int?
+  /// (LINUX only) Defines behavior of changing ownership and permission of the volume before being exposed
+  /// inside the containers.
+  public let fsGroupChangePolicy: FsGroupChangePolicy?
+
+  public init(
+    securityContextType: SecurityContextType,
+    fsGroup: Int? = nil,
+    fsGroupChangePolicy: FsGroupChangePolicy? = nil
+  ) {
+    self.securityContextType = securityContextType
+    self.fsGroup = fsGroup
+    self.fsGroupChangePolicy = fsGroupChangePolicy
+  }
+
+  /// Creates a security context for all containers in a Linux container instance.
+  public static func linux(
+    fsGroup: Int? = nil,
+    fsGroupChangePolicy: FsGroupChangePolicy? = nil
+  ) -> CreateContainerInstanceSecurityContextDetails {
+    CreateContainerInstanceSecurityContextDetails(
+      securityContextType: .linux,
+      fsGroup: fsGroup,
+      fsGroupChangePolicy: fsGroupChangePolicy
+    )
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceSecurityContextDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceSecurityContextDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceShapeConfigDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceShapeConfigDetails.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The size and amount of resources available to the container instance.
+public struct CreateContainerInstanceShapeConfigDetails: Codable {
+  /// The total number of OCPUs available to the container instance.
+  public let ocpus: Float
+  /// The total amount of memory available to the container instance (GB).
+  public let memoryInGBs: Float?
+
+  public init(ocpus: Float, memoryInGBs: Float? = nil) {
+    self.ocpus = ocpus
+    self.memoryInGBs = memoryInGBs
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceShapeConfigDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerInstanceShapeConfigDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerResourceConfigDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerResourceConfigDetails.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The size and amount of resources available to the container.
+public struct CreateContainerResourceConfigDetails: Codable {
+  /// The maximum amount of CPUs that can be consumed by the container's process. If you do not set a value, then the process can use all available CPU resources on the instance. CPU usage is defined in terms of logical CPUs. Values can be fractional. A value of "1.5" means that the container can consume at most the equivalent of 1 and a half logical CPUs worth of CPU capacity.
+  public let vcpusLimit: Float?
+  /// The maximum amount of memory that can be consumed by the container's process. If you do not set a value, then the process may use all available memory on the instance.
+  public let memoryLimitInGBs: Float?
+
+  public init(vcpusLimit: Float? = nil, memoryLimitInGBs: Float? = nil) {
+    self.vcpusLimit = vcpusLimit
+    self.memoryLimitInGBs = memoryLimitInGBs
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerResourceConfigDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerResourceConfigDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerVnicDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerVnicDetails.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Information to create a virtual network interface card (VNIC) which gives the containers on this
+/// container instance access to a virtual client network (VCN).
+///
+/// You use this object when creating the primary VNIC during container instance launch or when
+/// creating a secondary VNIC. This VNIC is created in the same compartment as the specified subnet
+/// on behalf of the customer. The VNIC created by this call contains both the tags specified in this
+/// object as well as any tags specified in the parent container instance.
+public struct CreateContainerVnicDetails: Codable {
+  /// A user-friendly name for the VNIC. Does not have to be unique. Avoid entering confidential information.
+  public let displayName: String?
+  /// The hostname for the VNIC's primary private IP. Used for DNS.
+  public let hostnameLabel: String?
+  /// Whether the VNIC should be assigned a public IP address.
+  public let isPublicIpAssigned: Bool?
+  /// Whether the source/destination check is disabled on the VNIC.
+  public let skipSourceDestCheck: Bool?
+  /// A list of the OCIDs of the network security groups (NSGs) to add the VNIC to.
+  public let nsgIds: [String]?
+  /// A private IP address of your choice to assign to the VNIC. Must be an available IP address within the subnet's CIDR.
+  public let privateIp: String?
+  /// The OCID of the subnet to create the VNIC in.
+  public let subnetId: String
+  /// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only. Example: `{"bar-key": "value"}`
+  public let freeformTags: [String: String]?
+  /// Defined tags for this resource. Each key is predefined and scoped to a namespace. Example: `{"foo-namespace": {"bar-key": "value"}}`.
+  public let definedTags: [String: [String: String]]?
+
+  public init(
+    displayName: String? = nil,
+    hostnameLabel: String? = nil,
+    isPublicIpAssigned: Bool? = nil,
+    skipSourceDestCheck: Bool? = nil,
+    nsgIds: [String]? = nil,
+    privateIp: String? = nil,
+    subnetId: String,
+    freeformTags: [String: String]? = nil,
+    definedTags: [String: [String: String]]? = nil
+  ) {
+    self.displayName = displayName
+    self.hostnameLabel = hostnameLabel
+    self.isPublicIpAssigned = isPublicIpAssigned
+    self.skipSourceDestCheck = skipSourceDestCheck
+    self.nsgIds = nsgIds
+    self.privateIp = privateIp
+    self.subnetId = subnetId
+    self.freeformTags = freeformTags
+    self.definedTags = definedTags
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerVnicDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerVnicDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerVolumeDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerVolumeDetails.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A volume represents a directory with data that is accessible across multiple containers in a container instance.
+public struct CreateContainerVolumeDetails: Codable {
+  /// The name of the volume. This must be unique within a single container instance.
+  public let name: String
+  /// The type of volume.
+  public let volumeType: ContainerVolumeType
+  /// (EMPTYDIR only) The volume type of the empty directory, can be either File Storage or Memory.
+  public let backingStore: String?
+  /// (CONFIGFILE only) Contains key value pairs which can be mounted as individual files inside the container. The value needs to be base64 encoded. It is decoded to plain text before the mount.
+  public let configs: [ContainerConfigFile]?
+
+  public init(name: String, volumeType: ContainerVolumeType, backingStore: String? = nil, configs: [ContainerConfigFile]? = nil) {
+    self.name = name
+    self.volumeType = volumeType
+    self.backingStore = backingStore
+    self.configs = configs
+  }
+
+  /// Creates an EMPTYDIR volume.
+  public static func emptyDir(name: String, backingStore: String? = nil) -> CreateContainerVolumeDetails {
+    CreateContainerVolumeDetails(name: name, volumeType: .emptyDir, backingStore: backingStore)
+  }
+
+  /// Creates a CONFIGFILE volume.
+  public static func configFile(name: String, configs: [ContainerConfigFile]) -> CreateContainerVolumeDetails {
+    CreateContainerVolumeDetails(name: name, volumeType: .configFile, configs: configs)
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerVolumeDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateContainerVolumeDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateImagePullSecretDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateImagePullSecretDetails.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The image pull secrets for accessing private registry to pull images for containers.
+public struct CreateImagePullSecretDetails: Codable {
+  /// The type of ImagePullSecret.
+  public let secretType: ImagePullSecretType
+  /// The registry endpoint of the container image.
+  public let registryEndpoint: String
+  /// (BASIC only) The username which should be used with the registry for authentication. The value is expected in base64 format.
+  public let username: String?
+  /// (BASIC only) The password which should be used with the registry for authentication. The value is expected in base64 format.
+  public let password: String?
+  /// (VAULT only) The OCID of the secret for registry credentials.
+  public let secretId: String?
+
+  public init(
+    secretType: ImagePullSecretType,
+    registryEndpoint: String,
+    username: String? = nil,
+    password: String? = nil,
+    secretId: String? = nil
+  ) {
+    self.secretType = secretType
+    self.registryEndpoint = registryEndpoint
+    self.username = username
+    self.password = password
+    self.secretId = secretId
+  }
+
+  /// Creates a BASIC image pull secret which accepts username and password (base64-encoded) as credentials.
+  public static func basic(registryEndpoint: String, username: String, password: String) -> CreateImagePullSecretDetails {
+    CreateImagePullSecretDetails(secretType: .basic, registryEndpoint: registryEndpoint, username: username, password: password)
+  }
+
+  /// Creates a VAULT image pull secret which accepts a secret OCID as credentials.
+  public static func vault(registryEndpoint: String, secretId: String) -> CreateImagePullSecretDetails {
+    CreateImagePullSecretDetails(secretType: .vault, registryEndpoint: registryEndpoint, secretId: secretId)
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateImagePullSecretDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateImagePullSecretDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateSecurityContextDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateSecurityContextDetails.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Security context for container.
+public struct CreateSecurityContextDetails: Codable {
+  /// The type of security context.
+  public let securityContextType: SecurityContextType
+  /// (LINUX only) The user ID (UID) to run the entrypoint process of the container. Defaults to user
+  /// specified UID in container image metadata if not provided. This must be provided if runAsGroup is provided.
+  public let runAsUser: Int?
+  /// (LINUX only) The group ID (GID) to run the entrypoint process of the container. Uses runtime default if not provided.
+  public let runAsGroup: Int?
+  /// (LINUX only) Indicates if the container must run as a non-root user. If true, the service validates the
+  /// container image at runtime to ensure that it is not going to run with UID 0 (root) and fails the
+  /// container instance creation if the validation fails.
+  public let isNonRootUserCheckEnabled: Bool?
+  /// (LINUX only) Determines if the container will have a read-only root file system. Default value is false.
+  public let isRootFileSystemReadonly: Bool?
+  /// (LINUX only) Linux container capabilities to configure capabilities of the container.
+  public let capabilities: ContainerCapabilities?
+
+  public init(
+    securityContextType: SecurityContextType,
+    runAsUser: Int? = nil,
+    runAsGroup: Int? = nil,
+    isNonRootUserCheckEnabled: Bool? = nil,
+    isRootFileSystemReadonly: Bool? = nil,
+    capabilities: ContainerCapabilities? = nil
+  ) {
+    self.securityContextType = securityContextType
+    self.runAsUser = runAsUser
+    self.runAsGroup = runAsGroup
+    self.isNonRootUserCheckEnabled = isNonRootUserCheckEnabled
+    self.isRootFileSystemReadonly = isRootFileSystemReadonly
+    self.capabilities = capabilities
+  }
+
+  /// Creates a security context for a Linux container.
+  public static func linux(
+    runAsUser: Int? = nil,
+    runAsGroup: Int? = nil,
+    isNonRootUserCheckEnabled: Bool? = nil,
+    isRootFileSystemReadonly: Bool? = nil,
+    capabilities: ContainerCapabilities? = nil
+  ) -> CreateSecurityContextDetails {
+    CreateSecurityContextDetails(
+      securityContextType: .linux,
+      runAsUser: runAsUser,
+      runAsGroup: runAsGroup,
+      isNonRootUserCheckEnabled: isNonRootUserCheckEnabled,
+      isRootFileSystemReadonly: isRootFileSystemReadonly,
+      capabilities: capabilities
+    )
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateSecurityContextDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateSecurityContextDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateVolumeMountDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateVolumeMountDetails.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Defines the mapping from volume to a mount path in a container.
+public struct CreateVolumeMountDetails: Codable {
+  /// The volume access path.
+  public let mountPath: String
+  /// The name of the volume. Avoid entering confidential information.
+  public let volumeName: String
+  /// A subpath inside the referenced volume.
+  public let subPath: String?
+  /// Whether the volume was mounted in read-only mode. By default, the volume is not read-only.
+  public let isReadOnly: Bool?
+  /// If there is more than one partition in the volume, reference this number of partitions.
+  public let partition: Int?
+
+  public init(
+    mountPath: String,
+    volumeName: String,
+    subPath: String? = nil,
+    isReadOnly: Bool? = nil,
+    partition: Int? = nil
+  ) {
+    self.mountPath = mountPath
+    self.volumeName = volumeName
+    self.subPath = subPath
+    self.isReadOnly = isReadOnly
+    self.partition = partition
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/CreateVolumeMountDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/CreateVolumeMountDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/FsGroupChangePolicy.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/FsGroupChangePolicy.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Defines behavior of changing ownership and permission of the volume before being exposed inside
+/// the containers. This only applies to volumes which support fsGroup ownership and permissions,
+/// and will have no effect on ephemeral volumes. ON_ROOT_MISMATCH only changes permissions and
+/// ownership if the permission and ownership of the root directory does not match the expected
+/// permissions and ownership of the volume. This can improve container instance start times.
+/// ALWAYS changes permission and ownership of the volume when it is mounted. If unset, ALWAYS is used.
+public enum FsGroupChangePolicy: String, Codable, Sendable {
+  case always = "ALWAYS"
+  case onRootMismatch = "ON_ROOT_MISMATCH"
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/FsGroupChangePolicy.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/FsGroupChangePolicy.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/HealthCheckHttpHeader.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/HealthCheckHttpHeader.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Container HTTP headers for an HTTP health check.
+public struct HealthCheckHttpHeader: Codable {
+  /// Container HTTP header key.
+  public let name: String?
+  /// Container HTTP header value.
+  public let value: String?
+
+  public init(name: String? = nil, value: String? = nil) {
+    self.name = name
+    self.value = value
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/HealthCheckHttpHeader.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/HealthCheckHttpHeader.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ImagePullSecret.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ImagePullSecret.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The image pull secrets for accessing private registry to pull images for containers.
+public struct ImagePullSecret: Codable {
+  /// The type of ImagePullSecret.
+  public let secretType: ImagePullSecretType
+  /// The registry endpoint of the container image.
+  public let registryEndpoint: String
+
+  public init(secretType: ImagePullSecretType, registryEndpoint: String) {
+    self.secretType = secretType
+    self.registryEndpoint = registryEndpoint
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ImagePullSecret.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ImagePullSecret.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/SecurityContext.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/SecurityContext.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Security context for container.
+public struct SecurityContext: Codable {
+  /// The type of security context.
+  public let securityContextType: SecurityContextType
+  /// (LINUX only) The user ID (UID) to run the entrypoint process of the container. Defaults to user
+  /// specified UID in container image metadata if not provided. This must be provided if runAsGroup is provided.
+  public let runAsUser: Int?
+  /// (LINUX only) The group ID (GID) to run the entrypoint process of the container. Uses runtime default if not provided.
+  public let runAsGroup: Int?
+  /// (LINUX only) Indicates if the container must run as a non-root user. If true, the service validates the
+  /// container image at runtime to ensure that it is not going to run with UID 0 (root) and fails the
+  /// container instance creation if the validation fails.
+  public let isNonRootUserCheckEnabled: Bool?
+  /// (LINUX only) Determines if the container will have a read-only root file system. Default value is false.
+  public let isRootFileSystemReadonly: Bool?
+  /// (LINUX only) Linux container capabilities to configure capabilities of the container.
+  public let capabilities: ContainerCapabilities?
+
+  public init(
+    securityContextType: SecurityContextType,
+    runAsUser: Int? = nil,
+    runAsGroup: Int? = nil,
+    isNonRootUserCheckEnabled: Bool? = nil,
+    isRootFileSystemReadonly: Bool? = nil,
+    capabilities: ContainerCapabilities? = nil
+  ) {
+    self.securityContextType = securityContextType
+    self.runAsUser = runAsUser
+    self.runAsGroup = runAsGroup
+    self.isNonRootUserCheckEnabled = isNonRootUserCheckEnabled
+    self.isRootFileSystemReadonly = isRootFileSystemReadonly
+    self.capabilities = capabilities
+  }
+
+  /// Creates a security context for a Linux container.
+  public static func linux(
+    runAsUser: Int? = nil,
+    runAsGroup: Int? = nil,
+    isNonRootUserCheckEnabled: Bool? = nil,
+    isRootFileSystemReadonly: Bool? = nil,
+    capabilities: ContainerCapabilities? = nil
+  ) -> SecurityContext {
+    SecurityContext(
+      securityContextType: .linux,
+      runAsUser: runAsUser,
+      runAsGroup: runAsGroup,
+      isNonRootUserCheckEnabled: isNonRootUserCheckEnabled,
+      isRootFileSystemReadonly: isRootFileSystemReadonly,
+      capabilities: capabilities
+    )
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/SecurityContext.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/SecurityContext.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ShapeMemoryOptions.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ShapeMemoryOptions.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// For a flexible shape, the amount of memory available for container instances that use this shape.
+public struct ShapeMemoryOptions: Codable {
+  /// The minimum amount of memory (GB).
+  public let minInGBs: Float?
+  /// The maximum amount of memory (GB).
+  public let maxInGBs: Float?
+  /// The default amount of memory per OCPU available for this shape (GB).
+  public let defaultPerOcpuInGBs: Float?
+  /// The minimum amount of memory per OCPU available for this shape (GB).
+  public let minPerOcpuInGBs: Float?
+  /// The maximum amount of memory per OCPU available for this shape (GB).
+  public let maxPerOcpuInGBs: Float?
+
+  public init(
+    minInGBs: Float? = nil,
+    maxInGBs: Float? = nil,
+    defaultPerOcpuInGBs: Float? = nil,
+    minPerOcpuInGBs: Float? = nil,
+    maxPerOcpuInGBs: Float? = nil
+  ) {
+    self.minInGBs = minInGBs
+    self.maxInGBs = maxInGBs
+    self.defaultPerOcpuInGBs = defaultPerOcpuInGBs
+    self.minPerOcpuInGBs = minPerOcpuInGBs
+    self.maxPerOcpuInGBs = maxPerOcpuInGBs
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ShapeMemoryOptions.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ShapeMemoryOptions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ShapeNetworkingBandwidthOptions.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ShapeNetworkingBandwidthOptions.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// For a flexible shape, the amount of networking bandwidth available for container instances that use this shape.
+public struct ShapeNetworkingBandwidthOptions: Codable {
+  /// The minimum amount of networking bandwidth, in gigabits per second.
+  public let minInGbps: Float?
+  /// The maximum amount of networking bandwidth, in gigabits per second.
+  public let maxInGbps: Float?
+  /// The default amount of networking bandwidth per OCPU, in gigabits per second.
+  public let defaultPerOcpuInGbps: Float?
+
+  public init(
+    minInGbps: Float? = nil,
+    maxInGbps: Float? = nil,
+    defaultPerOcpuInGbps: Float? = nil
+  ) {
+    self.minInGbps = minInGbps
+    self.maxInGbps = maxInGbps
+    self.defaultPerOcpuInGbps = defaultPerOcpuInGbps
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ShapeNetworkingBandwidthOptions.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ShapeNetworkingBandwidthOptions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/ShapeOcpuOptions.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ShapeOcpuOptions.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// For a flexible shape, the number of OCPUs available for container instances that use this shape.
+public struct ShapeOcpuOptions: Codable {
+  /// The minimum number of OCPUs.
+  public let min: Float?
+  /// The maximum number of OCPUs.
+  public let max: Float?
+
+  public init(min: Float? = nil, max: Float? = nil) {
+    self.min = min
+    self.max = max
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/ShapeOcpuOptions.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/ShapeOcpuOptions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/UpdateContainerDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/UpdateContainerDetails.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The container information to be updated.
+public struct UpdateContainerDetails: Codable {
+  /// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+  public let displayName: String?
+  /// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only. Example: `{"bar-key": "value"}`
+  public let freeformTags: [String: String]?
+  /// Defined tags for this resource. Each key is predefined and scoped to a namespace. Example: `{"foo-namespace": {"bar-key": "value"}}`.
+  public let definedTags: [String: [String: String]]?
+
+  public init(
+    displayName: String? = nil,
+    freeformTags: [String: String]? = nil,
+    definedTags: [String: [String: String]]? = nil
+  ) {
+    self.displayName = displayName
+    self.freeformTags = freeformTags
+    self.definedTags = definedTags
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/UpdateContainerDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/UpdateContainerDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/UpdateContainerInstanceDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/UpdateContainerInstanceDetails.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The information to be updated.
+public struct UpdateContainerInstanceDetails: Codable {
+  /// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+  public let displayName: String?
+  /// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only. Example: `{"bar-key": "value"}`
+  public let freeformTags: [String: String]?
+  /// Defined tags for this resource. Each key is predefined and scoped to a namespace. Example: `{"foo-namespace": {"bar-key": "value"}}`.
+  public let definedTags: [String: [String: String]]?
+
+  public init(
+    displayName: String? = nil,
+    freeformTags: [String: String]? = nil,
+    definedTags: [String: [String: String]]? = nil
+  ) {
+    self.displayName = displayName
+    self.freeformTags = freeformTags
+    self.definedTags = definedTags
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/UpdateContainerInstanceDetails.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/UpdateContainerInstanceDetails.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/services/ContainerInstances/Models/VolumeMount.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/VolumeMount.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Define the mapping from volume to a mount path in container.
+public struct VolumeMount: Codable {
+  /// Describes the volume access path.
+  public let mountPath: String
+  /// The name of the volume.
+  public let volumeName: String
+  /// A sub-path inside the referenced volume.
+  public let subPath: String?
+  /// Whether the volume was mounted in read-only mode. By default, the volume is mounted with write access.
+  public let isReadOnly: Bool?
+  /// If there is more than one partition in the volume, reference this number of partitions.
+  public let partition: Int?
+
+  public init(
+    mountPath: String,
+    volumeName: String,
+    subPath: String? = nil,
+    isReadOnly: Bool? = nil,
+    partition: Int? = nil
+  ) {
+    self.mountPath = mountPath
+    self.volumeName = volumeName
+    self.subPath = subPath
+    self.isReadOnly = isReadOnly
+    self.partition = partition
+  }
+}

--- a/Sources/OCIKit/services/ContainerInstances/Models/VolumeMount.swift
+++ b/Sources/OCIKit/services/ContainerInstances/Models/VolumeMount.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Tests/Services/ContainerInstancesTest.swift
+++ b/Tests/Services/ContainerInstancesTest.swift
@@ -1,0 +1,304 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import OCIKit
+
+// MARK: - Router
+
+struct ContainerInstancesRouterTests {
+  @Test("Create/list container instances route to the collection path")
+  func containerInstancesCollectionPath() {
+    #expect(ContainerInstancesAPI.createContainerInstance().path == "/20210415/containerInstances")
+    #expect(ContainerInstancesAPI.createContainerInstance().method == .post)
+    #expect(ContainerInstancesAPI.listContainerInstances(compartmentId: "ocid1.compartment").path == "/20210415/containerInstances")
+    #expect(ContainerInstancesAPI.listContainerInstances(compartmentId: "ocid1.compartment").method == .get)
+  }
+
+  @Test("Get/update/delete route to the resource path with the OCID")
+  func containerInstanceResourcePath() {
+    let id = "ocid1.containerinstance.oc1..aaaa"
+    #expect(ContainerInstancesAPI.getContainerInstance(containerInstanceId: id).path == "/20210415/containerInstances/\(id)")
+    #expect(ContainerInstancesAPI.getContainerInstance(containerInstanceId: id).method == .get)
+    #expect(ContainerInstancesAPI.updateContainerInstance(containerInstanceId: id).method == .put)
+    #expect(ContainerInstancesAPI.deleteContainerInstance(containerInstanceId: id).method == .delete)
+  }
+
+  @Test("Lifecycle actions route to /actions/<verb>")
+  func lifecycleActionPaths() {
+    let id = "ocid1.containerinstance.oc1..aaaa"
+    #expect(ContainerInstancesAPI.startContainerInstance(containerInstanceId: id).path == "/20210415/containerInstances/\(id)/actions/start")
+    #expect(ContainerInstancesAPI.stopContainerInstance(containerInstanceId: id).path == "/20210415/containerInstances/\(id)/actions/stop")
+    #expect(ContainerInstancesAPI.restartContainerInstance(containerInstanceId: id).path == "/20210415/containerInstances/\(id)/actions/restart")
+    #expect(
+      ContainerInstancesAPI.changeContainerInstanceCompartment(containerInstanceId: id).path
+        == "/20210415/containerInstances/\(id)/actions/changeCompartment")
+    #expect(ContainerInstancesAPI.startContainerInstance(containerInstanceId: id).method == .post)
+  }
+
+  @Test("Work request and container paths")
+  func otherResourcePaths() {
+    #expect(ContainerInstancesAPI.getContainer(containerId: "ocid1.container").path == "/20210415/containers/ocid1.container")
+    #expect(ContainerInstancesAPI.retrieveLogs(containerId: "ocid1.container").path == "/20210415/containers/ocid1.container/actions/retrieveLogs")
+    #expect(ContainerInstancesAPI.listContainerInstanceShapes(compartmentId: "c").path == "/20210415/containerInstanceShapes")
+    #expect(ContainerInstancesAPI.getWorkRequest(workRequestId: "wr1").path == "/20210415/workRequests/wr1")
+    #expect(ContainerInstancesAPI.listWorkRequestErrors(workRequestId: "wr1").path == "/20210415/workRequests/wr1/errors")
+    #expect(ContainerInstancesAPI.listWorkRequestLogs(workRequestId: "wr1").path == "/20210415/workRequests/wr1/logs")
+  }
+
+  @Test("List container instances assembles query items, filtering nils")
+  func listQueryItems() {
+    let items = ContainerInstancesAPI.listContainerInstances(
+      compartmentId: "ocid1.compartment",
+      lifecycleState: .active,
+      displayName: "web",
+      limit: 25,
+      sortOrder: .desc,
+      sortBy: .timeCreated
+    ).queryItems ?? []
+
+    let dict = Dictionary(uniqueKeysWithValues: items.map { ($0.name, $0.value) })
+    #expect(dict["compartmentId"] == "ocid1.compartment")
+    #expect(dict["lifecycleState"] == "ACTIVE")
+    #expect(dict["displayName"] == "web")
+    #expect(dict["limit"] == "25")
+    #expect(dict["sortOrder"] == "DESC")
+    #expect(dict["sortBy"] == "timeCreated")
+    // Unset optionals must be omitted.
+    #expect(dict["availabilityDomain"] == nil)
+    #expect(dict["page"] == nil)
+  }
+
+  @Test("retrieveLogs encodes isPrevious as a boolean string")
+  func retrieveLogsQuery() {
+    let onItems = ContainerInstancesAPI.retrieveLogs(containerId: "c", isPrevious: true).queryItems ?? []
+    #expect(onItems.first(where: { $0.name == "isPrevious" })?.value == "true")
+    // Omitted when nil.
+    #expect(ContainerInstancesAPI.retrieveLogs(containerId: "c").queryItems == nil)
+  }
+
+  @Test("Headers carry if-match, opc-request-id, and opc-retry-token where applicable")
+  func headers() {
+    let update = ContainerInstancesAPI.updateContainerInstance(
+      containerInstanceId: "id", ifMatch: "etag-123", opcRequestId: "req-1"
+    ).headers ?? [:]
+    #expect(update["if-match"] == "etag-123")
+    #expect(update["opc-request-id"] == "req-1")
+
+    let create = ContainerInstancesAPI.createContainerInstance(opcRetryToken: "tok", opcRequestId: "req-2").headers ?? [:]
+    #expect(create["opc-retry-token"] == "tok")
+    #expect(create["opc-request-id"] == "req-2")
+
+    // No headers set => nil.
+    #expect(ContainerInstancesAPI.getContainerInstance(containerInstanceId: "id").headers == nil)
+  }
+
+  @Test("buildRequest composes the full signed-ready URL")
+  func buildRequestURL() throws {
+    let endpoint = URL(string: "https://compute-containers.us-phoenix-1.oci.oraclecloud.com")!
+    let req = try buildRequest(
+      api: ContainerInstancesAPI.listContainerInstances(compartmentId: "ocid1.compartment"),
+      endpoint: endpoint
+    )
+    let url = req.url!.absoluteString
+    #expect(url.hasPrefix("https://compute-containers.us-phoenix-1.oci.oraclecloud.com/20210415/containerInstances?"))
+    #expect(url.contains("compartmentId=ocid1.compartment"))
+    #expect(req.httpMethod == "GET")
+  }
+}
+
+// MARK: - Enums
+
+struct ContainerInstancesEnumsTests {
+  @Test("Enum raw values match the OCI wire strings")
+  func rawValues() {
+    #expect(ContainerInstanceLifecycleState.active.rawValue == "ACTIVE")
+    #expect(ContainerInstanceLifecycleState.deleting.rawValue == "DELETING")
+    #expect(ContainerRestartPolicy.onFailure.rawValue == "ON_FAILURE")
+    #expect(ImagePullSecretType.vault.rawValue == "VAULT")
+    #expect(ContainerVolumeType.emptyDir.rawValue == "EMPTYDIR")
+    #expect(ContainerVolumeType.configFile.rawValue == "CONFIGFILE")
+    #expect(ContainerInstanceWorkRequestStatus.inProgress.rawValue == "IN_PROGRESS")
+    #expect(ContainerInstanceWorkRequestOperationType.createContainerInstance.rawValue == "CREATE_CONTAINER_INSTANCE")
+  }
+}
+
+// MARK: - Model encoding (request wire format)
+
+struct ContainerInstancesModelEncodingTests {
+  /// Encodes a value and returns the resulting JSON as a dictionary for inspection.
+  private func jsonObject<T: Encodable>(_ value: T) throws -> [String: Any] {
+    let data = try JSONEncoder().encode(value)
+    return try JSONSerialization.jsonObject(with: data) as! [String: Any]
+  }
+
+  @Test("Volume factories emit the correct discriminator and only the relevant fields")
+  func volumeUnionEncoding() throws {
+    let empty = try jsonObject(CreateContainerVolumeDetails.emptyDir(name: "scratch", backingStore: "MEMORY"))
+    #expect(empty["name"] as? String == "scratch")
+    #expect(empty["volumeType"] as? String == "EMPTYDIR")
+    #expect(empty["backingStore"] as? String == "MEMORY")
+    #expect(empty["configs"] == nil)  // omitted for EMPTYDIR
+
+    let config = try jsonObject(
+      CreateContainerVolumeDetails.configFile(
+        name: "cfg",
+        configs: [ContainerConfigFile(fileName: "app.conf", data: "aGVsbG8=")]
+      ))
+    #expect(config["volumeType"] as? String == "CONFIGFILE")
+    #expect(config["backingStore"] == nil)  // omitted for CONFIGFILE
+    let configs = config["configs"] as? [[String: Any]]
+    #expect(configs?.first?["fileName"] as? String == "app.conf")
+    #expect(configs?.first?["data"] as? String == "aGVsbG8=")
+  }
+
+  @Test("Image pull secret factories emit the discriminator and credentials")
+  func imagePullSecretEncoding() throws {
+    let basic = try jsonObject(CreateImagePullSecretDetails.basic(registryEndpoint: "iad.ocir.io", username: "dXNlcg==", password: "cGFzcw=="))
+    #expect(basic["secretType"] as? String == "BASIC")
+    #expect(basic["registryEndpoint"] as? String == "iad.ocir.io")
+    #expect(basic["username"] as? String == "dXNlcg==")
+    #expect(basic["secretId"] == nil)
+
+    let vault = try jsonObject(CreateImagePullSecretDetails.vault(registryEndpoint: "iad.ocir.io", secretId: "ocid1.vaultsecret"))
+    #expect(vault["secretType"] as? String == "VAULT")
+    #expect(vault["secretId"] as? String == "ocid1.vaultsecret")
+    #expect(vault["username"] == nil)
+  }
+
+  @Test("A full create-instance payload nests required objects with correct keys")
+  func createInstanceEncoding() throws {
+    let details = CreateContainerInstanceDetails(
+      compartmentId: "ocid1.compartment",
+      availabilityDomain: "AD-1",
+      shape: "CI.Standard.E4.Flex",
+      shapeConfig: CreateContainerInstanceShapeConfigDetails(ocpus: 1, memoryInGBs: 4),
+      containers: [CreateContainerDetails(imageUrl: "iad.ocir.io/ns/app:latest")],
+      vnics: [CreateContainerVnicDetails(subnetId: "ocid1.subnet")],
+      containerRestartPolicy: .always
+    )
+    let json = try jsonObject(details)
+    #expect(json["compartmentId"] as? String == "ocid1.compartment")
+    #expect(json["availabilityDomain"] as? String == "AD-1")
+    #expect(json["shape"] as? String == "CI.Standard.E4.Flex")
+    #expect(json["containerRestartPolicy"] as? String == "ALWAYS")
+
+    let shapeConfig = json["shapeConfig"] as? [String: Any]
+    #expect(shapeConfig?["ocpus"] as? Double == 1)
+    #expect(shapeConfig?["memoryInGBs"] as? Double == 4)
+
+    let containers = json["containers"] as? [[String: Any]]
+    #expect(containers?.first?["imageUrl"] as? String == "iad.ocir.io/ns/app:latest")
+
+    let vnics = json["vnics"] as? [[String: Any]]
+    #expect(vnics?.first?["subnetId"] as? String == "ocid1.subnet")
+  }
+}
+
+// MARK: - Model decoding (response wire format)
+
+struct ContainerInstancesModelDecodingTests {
+  @Test("Decodes a container instance with nested objects, enums, and dates")
+  func decodesContainerInstance() throws {
+    let json = """
+      {
+        "id": "ocid1.containerinstance.oc1..aaaa",
+        "displayName": "my-instance",
+        "compartmentId": "ocid1.compartment.oc1..bbbb",
+        "availabilityDomain": "Uocm:PHX-AD-1",
+        "lifecycleState": "ACTIVE",
+        "containers": [{ "containerId": "ocid1.container.oc1..cccc" }],
+        "containerCount": 1,
+        "timeCreated": "2025-01-15T10:30:00.000Z",
+        "shape": "CI.Standard.E4.Flex",
+        "shapeConfig": {
+          "ocpus": 1.0,
+          "memoryInGBs": 4.0,
+          "processorDescription": "AMD EPYC",
+          "networkingBandwidthInGbps": 1.0
+        },
+        "vnics": [{ "vnicId": "ocid1.vnic.oc1..dddd" }],
+        "containerRestartPolicy": "ALWAYS",
+        "volumeCount": 0
+      }
+      """
+    let instance = try JSONDecoder().decode(ContainerInstance.self, from: json.data(using: .utf8)!)
+    #expect(instance.id == "ocid1.containerinstance.oc1..aaaa")
+    #expect(instance.lifecycleState == .active)
+    #expect(instance.containerRestartPolicy == .always)
+    #expect(instance.containerCount == 1)
+    #expect(instance.containers.first?.containerId == "ocid1.container.oc1..cccc")
+    #expect(instance.shapeConfig.processorDescription == "AMD EPYC")
+    #expect(instance.vnics.first?.vnicId == "ocid1.vnic.oc1..dddd")
+    #expect(instance.timeCreated != nil)
+  }
+
+  @Test("Decodes a container instance collection")
+  func decodesCollection() throws {
+    let json = """
+      {
+        "items": [
+          {
+            "id": "ocid1.ci.1", "displayName": "a", "compartmentId": "c",
+            "availabilityDomain": "AD-1", "lifecycleState": "CREATING",
+            "containerCount": 2, "timeCreated": "2025-01-15T10:30:00.000Z",
+            "shape": "CI.Standard.E4.Flex",
+            "shapeConfig": { "ocpus": 1.0, "memoryInGBs": 2.0, "processorDescription": "x", "networkingBandwidthInGbps": 1.0 },
+            "containerRestartPolicy": "NEVER"
+          }
+        ]
+      }
+      """
+    let collection = try JSONDecoder().decode(ContainerInstanceCollection.self, from: json.data(using: .utf8)!)
+    #expect(collection.items.count == 1)
+    #expect(collection.items.first?.lifecycleState == .creating)
+    #expect(collection.items.first?.containerRestartPolicy == .never)
+  }
+
+  @Test("Decodes a work request with status, operation type, and dates")
+  func decodesWorkRequest() throws {
+    let json = """
+      {
+        "operationType": "CREATE_CONTAINER_INSTANCE",
+        "status": "IN_PROGRESS",
+        "id": "ocid1.workrequest.oc1..eeee",
+        "compartmentId": "ocid1.compartment.oc1..ffff",
+        "resources": [
+          { "entityType": "containerInstance", "actionType": "CREATED", "identifier": "ocid1.ci.1" }
+        ],
+        "percentComplete": 42.5,
+        "timeAccepted": "2025-01-15T10:30:00.000Z"
+      }
+      """
+    let wr = try JSONDecoder().decode(ContainerInstanceWorkRequest.self, from: json.data(using: .utf8)!)
+    #expect(wr.operationType == .createContainerInstance)
+    #expect(wr.status == .inProgress)
+    #expect(wr.percentComplete == 42.5)
+    #expect(wr.resources.first?.actionType == .created)
+    #expect(wr.timeAccepted != nil)
+  }
+
+  @Test("Decodes a polymorphic container volume by discriminator")
+  func decodesVolumeUnion() throws {
+    let json = """
+      { "name": "scratch", "volumeType": "EMPTYDIR", "backingStore": "EPHEMERAL_STORAGE" }
+      """
+    let volume = try JSONDecoder().decode(ContainerVolume.self, from: json.data(using: .utf8)!)
+    #expect(volume.name == "scratch")
+    #expect(volume.volumeType == .emptyDir)
+    #expect(volume.backingStore == "EPHEMERAL_STORAGE")
+  }
+}

--- a/Tests/Services/ContainerInstancesTest.swift
+++ b/Tests/Services/ContainerInstancesTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Tests/Services/ResourcePrincipalTest.swift
+++ b/Tests/Services/ResourcePrincipalTest.swift
@@ -1,0 +1,175 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import Foundation
+import Testing
+import _CryptoExtras
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+@testable import OCIKit
+
+// MARK: - Helpers
+
+/// Base64url-encodes without padding (JWT segment encoding).
+private func base64URL(_ data: Data) -> String {
+  data.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+}
+
+/// Builds an unsigned-but-well-formed JWT string whose payload carries the given
+/// claims. The Resource Principal signer never verifies the signature, so the
+/// signature segment is a placeholder.
+private func makeJWT(claims: [String: Any]) -> String {
+  let header = try! JSONSerialization.data(withJSONObject: ["alg": "RS256", "typ": "JWT"])
+  let payload = try! JSONSerialization.data(withJSONObject: claims)
+  return "\(base64URL(header)).\(base64URL(payload)).c2ln"
+}
+
+/// A freshly generated RSA private key and its PEM, for building signers.
+private func makeKeyPair() throws -> (key: _RSA.Signing.PrivateKey, pem: String) {
+  let key = try _RSA.Signing.PrivateKey(keySize: .bits2048)
+  return (key, key.pemRepresentation)
+}
+
+// MARK: - Source classification
+
+struct ResourcePrincipalSourceTests {
+  @Test("Absolute paths classify as files, everything else as literal values")
+  func detectsPathVsValue() {
+    #expect(ResourcePrincipalSource.detect("/etc/oci/rpst") == .file("/etc/oci/rpst"))
+    #expect(ResourcePrincipalSource.detect("/var/run/secrets/token") == .file("/var/run/secrets/token"))
+    // A JWT-looking literal is a value, not a path.
+    #expect(ResourcePrincipalSource.detect("eyJhbGciOiJSUzI1NiJ9.e30.sig") == .value("eyJhbGciOiJSUzI1NiJ9.e30.sig"))
+    #expect(ResourcePrincipalSource.detect("relative/path") == .value("relative/path"))
+  }
+
+  @Test("A literal value source resolves to itself")
+  func resolvesLiteral() throws {
+    let source = ResourcePrincipalSource.value("hello-token")
+    #expect(try source.resolve() == "hello-token")
+  }
+}
+
+// MARK: - RPST JWT parsing
+
+struct ResourcePrincipalTokenTests {
+  @Test("Reads the exp claim from a JWT payload")
+  func readsExp() {
+    let exp = 1_893_456_000  // 2030-01-01
+    let jwt = makeJWT(claims: ["exp": exp, "res_tenant": "ocid1.tenancy.oc1..aaaa"])
+    #expect(ResourcePrincipalToken.expiry(of: jwt) == exp)
+  }
+
+  @Test("Returns nil for a token without an exp claim")
+  func missingExpIsNil() {
+    let jwt = makeJWT(claims: ["res_tenant": "ocid1.tenancy.oc1..aaaa"])
+    #expect(ResourcePrincipalToken.expiry(of: jwt) == nil)
+  }
+
+  @Test("Returns nil for a malformed token")
+  func malformedIsNil() {
+    #expect(ResourcePrincipalToken.expiry(of: "not-a-jwt") == nil)
+  }
+}
+
+// MARK: - Environment parsing
+
+struct ResourcePrincipalEnvironmentTests {
+  @Test("Missing version throws versionNotDefined")
+  func missingVersion() {
+    #expect(throws: ResourcePrincipalError.versionNotDefined) {
+      _ = try ResourcePrincipalSigner.fromEnvironment([:])
+    }
+  }
+
+  @Test("Unsupported version throws unsupportedVersion")
+  func unsupportedVersion() {
+    #expect(throws: ResourcePrincipalError.unsupportedVersion("1.1")) {
+      _ = try ResourcePrincipalSigner.fromEnvironment(["OCI_RESOURCE_PRINCIPAL_VERSION": "1.1"])
+    }
+  }
+
+  @Test("Missing RPST throws missingSessionToken")
+  func missingRPST() throws {
+    let (_, pem) = try makeKeyPair()
+    #expect(throws: ResourcePrincipalError.missingSessionToken) {
+      _ = try ResourcePrincipalSigner.fromEnvironment([
+        "OCI_RESOURCE_PRINCIPAL_VERSION": "2.2",
+        "OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM": pem,
+      ])
+    }
+  }
+
+  @Test("Missing private key throws missingPrivateKey")
+  func missingKey() {
+    let jwt = makeJWT(claims: ["exp": 1_893_456_000])
+    #expect(throws: ResourcePrincipalError.missingPrivateKey) {
+      _ = try ResourcePrincipalSigner.fromEnvironment([
+        "OCI_RESOURCE_PRINCIPAL_VERSION": "2.2",
+        "OCI_RESOURCE_PRINCIPAL_RPST": jwt,
+      ])
+    }
+  }
+
+  @Test("Valid environment builds a signer and exposes the region")
+  func buildsFromEnvironment() throws {
+    let (_, pem) = try makeKeyPair()
+    let jwt = makeJWT(claims: ["exp": Int(Date().timeIntervalSince1970) + 3600])
+    let signer = try ResourcePrincipalSigner.fromEnvironment([
+      "OCI_RESOURCE_PRINCIPAL_VERSION": "2.2",
+      "OCI_RESOURCE_PRINCIPAL_RPST": jwt,
+      "OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM": pem,
+      "OCI_RESOURCE_PRINCIPAL_REGION": "us-phoenix-1",
+    ])
+    #expect(signer.region == "us-phoenix-1")
+  }
+}
+
+// MARK: - Signing
+
+struct ResourcePrincipalSigningTests {
+  @Test("Signs a request with an ST$<rpst> keyId")
+  func signsWithSecurityTokenKeyId() throws {
+    let (_, pem) = try makeKeyPair()
+    let jwt = makeJWT(claims: ["exp": Int(Date().timeIntervalSince1970) + 3600])
+    let signer = ResourcePrincipalSigner(sessionToken: jwt, privateKeyPEM: pem, region: "us-phoenix-1")
+
+    var req = URLRequest(url: URL(string: "https://objectstorage.us-phoenix-1.oraclecloud.com/n/")!)
+    req.httpMethod = "GET"
+    try signer.sign(&req)
+
+    let auth = req.value(forHTTPHeaderField: "Authorization")
+    #expect(auth != nil)
+    #expect(auth?.contains("keyId=\"ST$\(jwt)\"") == true)
+    #expect(auth?.contains("algorithm=\"rsa-sha256\"") == true)
+    // A GET must not sign a body.
+    #expect(auth?.contains("x-content-sha256") == false)
+  }
+
+  @Test("Invalid PEM surfaces as invalidPrivateKey at sign time")
+  func invalidKeyThrows() {
+    let jwt = makeJWT(claims: ["exp": Int(Date().timeIntervalSince1970) + 3600])
+    let signer = ResourcePrincipalSigner(sessionToken: jwt, privateKeyPEM: "not-a-pem", region: nil)
+    var req = URLRequest(url: URL(string: "https://example.com/")!)
+    #expect(throws: ResourcePrincipalError.invalidPrivateKey) {
+      try signer.sign(&req)
+    }
+  }
+}

--- a/Tests/Services/ResourcePrincipalTest.swift
+++ b/Tests/Services/ResourcePrincipalTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2025 Ilia Sazonov and the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information


### PR DESCRIPTION
## Summary

Adds **Resource Principal v2.2** authentication and a full **Container Instances** service client so Swift workloads can run in OCI Container Instances (and Functions / Data Science) and authenticate to OCI without an API key.

> Stacked on #71 (Linux CI branch). GitHub will retarget this to `main` once #71 merges.

### Resource Principal v2.2 — `Sources/OCIKit/core/ResourcePrincipalSigner.swift`
Port of the Python SDK's `EphemeralResourcePrincipalSigner`.
- Reads `OCI_RESOURCE_PRINCIPAL_{VERSION,RPST,PRIVATE_PEM,PRIVATE_PEM_PASSPHRASE,REGION}`. Each RPST/key value is a literal **or** an absolute file path (via `isabs`), matching the reference implementation exactly.
- Reuses the existing `SecurityTokenSigner` spine (`ST$<rpst>` keyId). Refreshes token + key from disk 60s before the JWT `exp`. **No network round-trip.**
- Fully cross-platform: swift-crypto only, no `Security`/`CryptoKit`.

```swift
let signer = try ResourcePrincipalSigner.fromEnvironment()
let client = try ObjectStorageClient(region: .fra, signer: signer)
```

### Container Instances — `Sources/OCIKit/services/ContainerInstances/`
Full 18-operation surface (create/get/list/update/delete, start/stop/restart, change-compartment, list-shapes, get/list containers, retrieve-logs, work-request get/list/errors/logs) with a router, ~48 Codable models, shared enums, and errors. Endpoint `compute-containers.{region}.oci.oraclecloud.com`, API version `20210415`. Polymorphic types (volumes, image-pull-secrets, health checks, security contexts) are flattened unions with ergonomic factories (`.emptyDir`, `.basic`/`.vault`, `.http`/`.tcp`, `.linux`).

### Tests / CI
28 credential-free unit tests (env parsing, `ST$` signing, router paths/queries/headers, union encode + date/enum decode), all added to `UNIT_TEST_FILTER` in `linux.yml`.

### Scoped deferrals (documented in README)
- **OKE Workload Identity** — its proxymux endpoint needs custom-CA TLS pinning that `URLSession` can't do on Linux (and needs the forbidden `Security` framework on Apple). Follow-up: add `async-http-client`, or install the cluster CA into the pod trust store.
- **FSS (File Storage) volume subtype** — the one advanced volume type; EMPTYDIR + CONFIGFILE are fully supported.

## Verification
- `swift build --build-tests` on macOS **and** Linux (`swift:6.2`) — library + all test targets compile.
- 28 unit tests pass on both platforms (including RSA signing).