### PR TITLE
Injectable HTTPClient transport + hermetic ObjectStorage tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ env:
   # Regex (OR-separated) of swift-testing suite type names that are pure unit
   # tests — no ~/.oci/config, no network, no env vars. These MUST pass in CI.
   UNIT_TEST_FILTER: >-
-    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests|ResourcePrincipalSourceTests|ResourcePrincipalTokenTests|ResourcePrincipalEnvironmentTests|ResourcePrincipalSigningTests|ContainerInstancesRouterTests|ContainerInstancesEnumsTests|ContainerInstancesModelEncodingTests|ContainerInstancesModelDecodingTests
+    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests|ResourcePrincipalSourceTests|ResourcePrincipalTokenTests|ResourcePrincipalEnvironmentTests|ResourcePrincipalSigningTests|ContainerInstancesRouterTests|ContainerInstancesEnumsTests|ContainerInstancesModelEncodingTests|ContainerInstancesModelDecodingTests|ObjectStorageHermeticTests
 
 jobs:
   build-and-test:

--- a/Sources/OCIKit/core/HTTPClient.swift
+++ b/Sources/OCIKit/core/HTTPClient.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2026 the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/core/HTTPClient.swift
+++ b/Sources/OCIKit/core/HTTPClient.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// An injectable HTTP transport used by service clients to perform requests.
+///
+/// The default ``live`` value performs real network I/O via `URLSession`. Tests
+/// — and advanced consumers such as custom proxying, retry, or request logging —
+/// can supply their own closure instead. Injecting a closure that returns canned
+/// `(Data, HTTPURLResponse)` fixtures lets a client's request-building and
+/// response-handling be exercised with no live OCI tenancy, credentials, or
+/// network access.
+public struct HTTPClient: Sendable {
+  /// Performs `request` and returns the response bytes and metadata.
+  public var data: @Sendable (_ request: URLRequest) async throws -> (Data, URLResponse)
+
+  public init(data: @escaping @Sendable (_ request: URLRequest) async throws -> (Data, URLResponse)) {
+    self.data = data
+  }
+
+  /// The production transport, backed by `URLSession.shared`.
+  ///
+  /// On Linux this resolves to the async shim in `URLSession+Linux.swift`, since
+  /// swift-corelibs-foundation's `URLSession` lacks the native async method.
+  public static let live = HTTPClient { request in
+    try await URLSession.shared.data(for: request)
+  }
+}

--- a/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
+++ b/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
@@ -25,6 +25,7 @@ public struct ObjectStorageClient: Sendable {
   let retryConfig: RetryConfig?
   let signer: Signer
   let logger: Logger
+  let httpClient: HTTPClient
 
   // MARK: - Initialization
   /// Initialize the object storage client
@@ -38,10 +39,11 @@ public struct ObjectStorageClient: Sendable {
   ///     - retryConfig: The retry configuration for this service client
   ///
   ///     Either a region or an endpoint must be specified. If an endpoint is specified, it will be used instead of the region.
-  public init(region: Region? = nil, endpoint: String? = nil, signer: Signer, retryConfig: RetryConfig? = nil, logger: Logger = Logger(label: "ObjectStorageClient")) throws {
+  public init(region: Region? = nil, endpoint: String? = nil, signer: Signer, retryConfig: RetryConfig? = nil, logger: Logger = Logger(label: "ObjectStorageClient"), httpClient: HTTPClient = .live) throws {
     self.signer = signer
     self.retryConfig = retryConfig
     self.logger = logger
+    self.httpClient = httpClient
 
     if let endpoint, let endpointURL = URL(string: endpoint) {
       self.endpoint = endpointURL
@@ -76,7 +78,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -137,7 +139,7 @@ public struct ObjectStorageClient: Sendable {
 
       try signer.sign(&req)
 
-      let (data, response) = try await URLSession.shared.data(for: req)
+      let (data, response) = try await httpClient.data(req)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -187,7 +189,7 @@ public struct ObjectStorageClient: Sendable {
 
       try signer.sign(&req)
 
-      let (data, response) = try await URLSession.shared.data(for: req)
+      let (data, response) = try await httpClient.data(req)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -254,7 +256,7 @@ public struct ObjectStorageClient: Sendable {
     req.httpBody = payload
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -314,7 +316,7 @@ public struct ObjectStorageClient: Sendable {
     req.httpBody = payload
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -369,7 +371,7 @@ public struct ObjectStorageClient: Sendable {
     req.httpBody = payload
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -414,7 +416,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -462,7 +464,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -514,7 +516,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -568,7 +570,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -620,7 +622,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -674,7 +676,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -720,7 +722,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -765,7 +767,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -847,7 +849,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -938,7 +940,7 @@ public struct ObjectStorageClient: Sendable {
 
     let req = try buildRequest(api: api, endpoint: baseURL)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1009,7 +1011,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1059,7 +1061,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1109,7 +1111,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1146,7 +1148,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1191,7 +1193,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1255,7 +1257,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1352,7 +1354,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1399,7 +1401,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1445,7 +1447,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1491,7 +1493,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1568,7 +1570,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1644,7 +1646,7 @@ public struct ObjectStorageClient: Sendable {
     }
     let req = try buildRequest(api: api, endpoint: baseURL)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1721,7 +1723,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1776,7 +1778,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1818,7 +1820,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1866,7 +1868,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1939,7 +1941,7 @@ public struct ObjectStorageClient: Sendable {
     try signer.sign(&req)
 
     self.logger.info("[putObject] Starting upload of \(objectName) to folder: \(toFolder ?? "/")")
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2027,7 +2029,7 @@ public struct ObjectStorageClient: Sendable {
 
     self.logger.info("[putObjectPAR] Starting upload of \(objectName) to folder: \(toFolder ?? "/")")
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2097,7 +2099,7 @@ public struct ObjectStorageClient: Sendable {
 
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2162,7 +2164,7 @@ public struct ObjectStorageClient: Sendable {
 
       try signer.sign(&req)
 
-      let (data, response) = try await URLSession.shared.data(for: req)
+      let (data, response) = try await httpClient.data(req)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2222,7 +2224,7 @@ public struct ObjectStorageClient: Sendable {
 
       try signer.sign(&req)
 
-      let (data, response) = try await URLSession.shared.data(for: req)
+      let (data, response) = try await httpClient.data(req)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2289,7 +2291,7 @@ public struct ObjectStorageClient: Sendable {
 
       try signer.sign(&req)
 
-      let (data, response) = try await URLSession.shared.data(for: req)
+      let (data, response) = try await httpClient.data(req)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2356,7 +2358,7 @@ public struct ObjectStorageClient: Sendable {
 
       try signer.sign(&req)
 
-      let (data, response) = try await URLSession.shared.data(for: req)
+      let (data, response) = try await httpClient.data(req)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2425,7 +2427,7 @@ public struct ObjectStorageClient: Sendable {
 
       try signer.sign(&req)
 
-      let (data, response) = try await URLSession.shared.data(for: req)
+      let (data, response) = try await httpClient.data(req)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2503,7 +2505,7 @@ public struct ObjectStorageClient: Sendable {
 
       try signer.sign(&req)
 
-      let (data, response) = try await URLSession.shared.data(for: req)
+      let (data, response) = try await httpClient.data(req)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2568,7 +2570,7 @@ public struct ObjectStorageClient: Sendable {
 
       try signer.sign(&req)
 
-      let (data, response) = try await URLSession.shared.data(for: req)
+      let (data, response) = try await httpClient.data(req)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")

--- a/Tests/Linux/PutObjectHeaderCasingDiagnostics.swift
+++ b/Tests/Linux/PutObjectHeaderCasingDiagnostics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2026 the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Tests/Services/ObjectStorageHermeticTests.swift
+++ b/Tests/Services/ObjectStorageHermeticTests.swift
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+//
+// Hermetic tests for ObjectStorageClient — no ~/.oci/config, no credentials, no
+// network. They inject a fake HTTPClient that records the outgoing request and
+// returns canned responses, so request-building and response-parsing are tested
+// deterministically and run anywhere (CI, fork PRs, offline).
+//
+
+import Foundation
+import OCIKit
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// A no-op signer. These tests exercise ObjectStorage's request/response logic,
+// not signature correctness (which is covered separately with a fixed key), so
+// no private key or config file is needed. It stamps an Authorization header so
+// tests can confirm the signer ran.
+private struct StubSigner: Signer {
+  func sign(_ req: inout URLRequest) throws {
+    req.setValue(#"Signature version="1""#, forHTTPHeaderField: "Authorization")
+  }
+}
+
+// Sendable-safe capture of the last request the client handed to the transport.
+private actor RequestRecorder {
+  private(set) var last: URLRequest?
+  func record(_ request: URLRequest) { last = request }
+}
+
+// Builds a client whose transport records the request and returns a canned response.
+private func makeClient(
+  status: Int,
+  body: Data,
+  responseHeaders: [String: String] = [:],
+  recorder: RequestRecorder
+) throws -> ObjectStorageClient {
+  let http = HTTPClient { request in
+    await recorder.record(request)
+    let response = HTTPURLResponse(
+      url: request.url!, statusCode: status, httpVersion: "HTTP/1.1", headerFields: responseHeaders
+    )!
+    return (body, response)
+  }
+  return try ObjectStorageClient(region: .iad, signer: StubSigner(), httpClient: http)
+}
+
+struct ObjectStorageHermeticTests {
+
+  // Response parsing + request shape, both from a canned 200.
+  @Test("getNamespace: builds GET /n and parses the quoted-string body")
+  func getNamespace() async throws {
+    let recorder = RequestRecorder()
+    let client = try makeClient(status: 200, body: Data(#""frjfldcyl3la""#.utf8), recorder: recorder)
+
+    let namespace = try await client.getNamespace()
+
+    #expect(namespace == "frjfldcyl3la")  // quotes trimmed by the client
+    let req = await recorder.last
+    #expect(req?.httpMethod == "GET")
+    #expect(req?.url?.host == "objectstorage.us-ashburn-1.oraclecloud.com")
+    #expect(req?.url?.path == "/n")
+    #expect(req?.value(forHTTPHeaderField: "Authorization") != nil)  // signer ran
+  }
+
+  // Query-parameter construction + JSON array decoding + RFC3339 parsing.
+  @Test("listBuckets: sends compartmentId/limit/fields query and decodes the array")
+  func listBuckets() async throws {
+    let recorder = RequestRecorder()
+    let json = """
+      [
+        {"compartmentId":"ocid1.compartment.oc1..c1","createdBy":"ocid1.user.oc1..u1","etag":"e1","name":"alpha","namespace":"frjfldcyl3la","timeCreated":"2026-07-14T12:00:00.000Z"},
+        {"compartmentId":"ocid1.compartment.oc1..c1","createdBy":"ocid1.user.oc1..u1","etag":"e2","name":"beta","namespace":"frjfldcyl3la","timeCreated":"2026-07-14T12:05:00.000Z"}
+      ]
+      """
+    let client = try makeClient(status: 200, body: Data(json.utf8), recorder: recorder)
+
+    let buckets = try await client.listBuckets(
+      namespaceName: "frjfldcyl3la",
+      compartmentId: "ocid1.compartment.oc1..c1",
+      limit: 10
+    )
+
+    #expect(buckets.map(\.name) == ["alpha", "beta"])
+    #expect(buckets.first?.timeCreated != nil)  // RFC3339 -> Date parsing exercised
+
+    let req = await recorder.last
+    #expect(req?.httpMethod == "GET")
+    #expect(req?.url?.path == "/n/frjfldcyl3la/b")
+    let items = req?.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false)?.queryItems } ?? []
+    let query = Dictionary(uniqueKeysWithValues: items.map { ($0.name, $0.value) })
+    #expect(query["compartmentId"] == "ocid1.compartment.oc1..c1")
+    #expect(query["limit"] == "10")
+    #expect(query["fields"] == "tags")  // default
+  }
+
+  // Write-path request shape (method, path, body). putObject also parses response
+  // headers case-sensitively; that is exactly the Linux header-casing behavior
+  // being addressed separately, so we ignore the call's outcome and assert only
+  // the request the SDK emitted (the recorder captured it before any parsing).
+  @Test("putObject: builds a PUT to /o/<object> with the payload as the body")
+  func putObjectRequestShape() async throws {
+    let recorder = RequestRecorder()
+    let client = try makeClient(status: 200, body: Data(), recorder: recorder)
+    let payload = Data("Hello, OCI!".utf8)
+
+    _ = try? await client.putObject(
+      namespaceName: "frjfldcyl3la",
+      bucketName: "test_bucket_by_sdk",
+      objectName: "greeting.txt",
+      putObjectBody: payload
+    )
+
+    let req = await recorder.last
+    #expect(req?.httpMethod == "PUT")
+    #expect(req?.url?.path == "/n/frjfldcyl3la/b/test_bucket_by_sdk/o/greeting.txt")
+    #expect(req?.httpBody == payload)
+  }
+
+  // Error path: a non-2xx with an OCI error body maps to unexpectedStatusCode.
+  // Trivial to exercise hermetically; nearly impossible to provoke reliably live.
+  @Test("getNamespace: non-2xx maps to ObjectStorageError with the server message")
+  func errorMapping() async throws {
+    let recorder = RequestRecorder()
+    let errorJSON = #"{"code":"NamespaceNotFound","message":"You do not have authorization"}"#
+    let client = try makeClient(status: 404, body: Data(errorJSON.utf8), recorder: recorder)
+
+    await #expect(throws: ObjectStorageError.self) {
+      _ = try await client.getNamespace()
+    }
+  }
+}

--- a/Tests/Services/ObjectStorageHermeticTests.swift
+++ b/Tests/Services/ObjectStorageHermeticTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2026 the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Tests/Services/ObjectStorageHermeticTests.swift
+++ b/Tests/Services/ObjectStorageHermeticTests.swift
@@ -52,7 +52,10 @@ private func makeClient(
   let http = HTTPClient { request in
     await recorder.record(request)
     let response = HTTPURLResponse(
-      url: request.url!, statusCode: status, httpVersion: "HTTP/1.1", headerFields: responseHeaders
+      url: request.url!,
+      statusCode: status,
+      httpVersion: "HTTP/1.1",
+      headerFields: responseHeaders
     )!
     return (body, response)
   }


### PR DESCRIPTION
Adds a small, dependency-free HTTP transport seam so service clients can be tested hermetically — no `~/.oci/config`, no network, no live OCI resources.

### What
- **`HTTPClient`** (`Sources/OCIKit/core/HTTPClient.swift`) — a `public`, `Sendable` struct-of-closures transport. Default `.live` is backed by `URLSession` (Linux shim aware). Consumers can inject their own (proxy, logging, tests).
- **`ObjectStorageClient`** takes `httpClient: HTTPClient = .live` (backward compatible) and routes its 42 send sites through it.
- **`ObjectStorageHermeticTests`** — 4 tests (getNamespace request+parse, listBuckets query+decode, putObject request shape, 404→`ObjectStorageError`), using a no-op signer + an `actor` request recorder.
- Wired into `UNIT_TEST_FILTER` so CI runs them.

### Cost
3 real lines of wiring in the client + 42 identical call-site swaps + the 44-line reusable `HTTPClient`. No new runtime dependencies.

### Verified
`swift build --build-tests` + the new suite pass on macOS (6.3.3) and Linux (aarch64 + x86_64, 6.2.4), in ~4ms.

First of a two-PR stack; the follow-up adds record/replay of real captured responses.