### PR TITLE
Record/replay HTTP fixtures: capture real OCI responses as mocks

### DIFF
--- a/.claude/skills/oci-capture-fixtures/SKILL.md
+++ b/.claude/skills/oci-capture-fixtures/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: oci-capture-fixtures
+description: Captures a real Oracle Cloud Infrastructure (OCI) wire response — and the request that produced it — into a committable JSON fixture under Tests/Services/Fixtures, using a live OCI config profile (default "DEFAULT"). Use when asked to "capture a real OCI response", "record a fixture from OCI", "capture <operation> from my <profile> profile", or "grab the real wire response" for an operation.
+---
+
+# Capture OCI wire fixtures
+
+Record one real OCI response through the SDK's own transport, sanitize it, and
+commit it so `oci-wire-tests` can replay it forever with no credentials or
+network. This is a **local, one-time, credential-gated step — never run in CI**.
+
+## 1. Confirm the target operation and that its client is seam-wired
+
+Every service client must take `httpClient: HTTPClient = .live`
+(`Sources/OCIKit/core/HTTPClient.swift`). Check the client struct for the
+operation you're capturing (e.g. `IAMClient`, `ObjectStorageClient`):
+
+```bash
+grep -n "httpClient" Sources/OCIKit/services/**/*.swift
+```
+
+- If it already takes `httpClient`, skip to step 2.
+- If not, wire it (3-line, backward-compatible change — the `.live` default means
+  no existing caller breaks):
+  1. Add a stored property: `let httpClient: HTTPClient`
+  2. Add a defaulted init parameter: `httpClient: HTTPClient = .live`
+  3. Assign it: `self.httpClient = httpClient`
+  Then find/replace every send site in that service file:
+  `- let (data, response) = try await URLSession.shared.data(for: req)`
+  `+ let (data, response) = try await httpClient.data(req)`
+  If the client doesn't exist yet at all, hand off to **oci-new-service-client**
+  first, then come back here.
+
+## 2. Resolve the profile's region and endpoint
+
+Read the region from `~/.oci/config` (or `OCI_CONFIG_FILE` if set) for the given
+profile (default `DEFAULT`) using `extractUserRegion` from
+`Sources/OCIKit/core/Region+Service.swift`:
+
+```swift
+let region = Region.from(regionId: try extractUserRegion(from: configFile, profile: profile) ?? "") ?? .iad
+```
+
+Most clients accept `region: Region` directly and derive the real host
+themselves; a few (like `ObjectStorageClient`) also accept an explicit
+`endpoint:` string (e.g. `https://objectstorage.us-ashburn-1.oraclecloud.com`) —
+use whichever the client's initializer exposes.
+
+## 3. Add (or reuse) a gated capture `@Test`
+
+Add a case to `Tests/Services/OCICaptureTests.swift` — it already self-skips
+unless its env vars are set, so it's safe to leave in the tree and never runs in
+CI. Follow the existing `captureGetNamespace` pattern: build the client with a
+**real `APIKeySigner`** from the profile and
+`httpClient: .recording(into: URL(filePath: out))`, then call the operation
+(pass any required real arguments, like `compartmentId` or `namespace`, via env
+vars — never hardcode them):
+
+```swift
+@Test func captureListCompartments() async throws {
+  let env = ProcessInfo.processInfo.environment
+  guard let out = env["OCI_FIXTURE_OUT"],
+        let configFile = env["OCI_CONFIG_FILE"],
+        let compartmentId = env["OCI_COMPARTMENT_ID"] else {
+    print("capture skipped — set OCI_FIXTURE_OUT, OCI_CONFIG_FILE, OCI_COMPARTMENT_ID")
+    return
+  }
+  let profile = env["OCI_PROFILE"] ?? "DEFAULT"
+  let signer = try APIKeySigner(configFilePath: configFile, configName: profile)
+  let region = Region.from(regionId: try extractUserRegion(from: configFile, profile: profile) ?? "") ?? .iad
+
+  let client = try IAMClient(
+    region: region, signer: signer,
+    httpClient: .recording(into: URL(filePath: out))   // wraps .live
+  )
+  _ = try await client.listCompartments(compartmentId: compartmentId)
+  // writes <out>/GET_20160918_compartments.json
+}
+```
+
+Run it once against the real tenancy:
+
+```bash
+OCI_CONFIG_FILE=$HOME/.oci/config OCI_PROFILE=DEFAULT \
+OCI_COMPARTMENT_ID=ocid1.tenancy.oc1..aaaa… \
+OCI_FIXTURE_OUT=/tmp/fixtures \
+swift test --filter OCICaptureTests
+```
+
+For a client that takes an explicit `endpoint:` (like `ObjectStorageClient`
+today), set `OCI_CAPTURE_BASE_URL=https://<service>.<region>.oraclecloud.com`
+instead of/alongside deriving `region`; see `OCICaptureTests.captureGetNamespace`
+for that shape. Operation-specific arguments (namespace, bucket, object name,
+etc.) are always passed through env vars, following the same pattern.
+
+The recording transport (`HTTPClient.recording(into:)` in
+`Sources/OCIKit/core/HTTPFixture.swift`) wraps `.live`, so it captures the
+response **exactly as the client sees it** — real status code, real header
+casing, real body — and writes it to
+`<OCI_FIXTURE_OUT>/<METHOD>_<sanitized-path>.json`.
+
+## 4. Sanitize before committing — this step is mandatory
+
+Open the captured JSON and scrub anything real:
+
+- OCIDs (tenancy, compartment, user, resource) → replace the unique suffix with
+  `EXAMPLE`, e.g. `ocid1.compartment.oc1..EXAMPLE`
+- Tenancy/company names, email addresses, real resource names
+- `opc-request-id` and any other request-id-shaped header → `EXAMPLE`
+- Pre-Authenticated Request (PAR) tokens, SAS-like tokens, or any secret body
+  content
+- The captured `request.url` (query params can carry the same OCIDs)
+
+Keep the **shape** intact: same JSON field names, same header keys, same
+structure — only the values change. The body is stored as `bodyBase64`; decode
+it, edit the JSON, re-encode:
+
+```bash
+python3 -c "import json,base64,pathlib
+p = pathlib.Path('/tmp/fixtures/GET_20160918_compartments.json')
+f = json.loads(p.read_text())
+body = json.loads(base64.b64decode(f['bodyBase64']))
+# ...edit body in place to replace real OCIDs/names with EXAMPLE...
+f['bodyBase64'] = base64.b64encode(json.dumps(body).encode()).decode()
+f['headers']['opc-request-id'] = 'EXAMPLE'
+p.write_text(json.dumps(f, indent=2, sort_keys=True))
+"
+```
+
+**Never commit an un-sanitized real response.** If in doubt, grep the file for
+`ocid1.` and the tenancy name before moving on.
+
+## 5. Move into place and verify it loads
+
+```bash
+cp /tmp/fixtures/GET_20160918_compartments.json \
+   Tests/Services/Fixtures/listCompartments.json
+```
+
+Verify it decodes with `HTTPFixture.load`, e.g. from a quick swift-testing
+assertion or a scratch script:
+
+```swift
+let fixture = try HTTPFixture.load(fromFile: URL(filePath: "Tests/Services/Fixtures/listCompartments.json"))
+#expect(fixture.statusCode == 200)
+```
+
+## Notes
+
+- The fixture only records `request.method` and `request.url` today (see
+  `HTTPFixture.Request` in `Sources/OCIKit/core/HTTPFixture.swift`). If the
+  replay test in `oci-wire-tests` needs to assert on request **headers or body**
+  (not just method/path/query), extend `HTTPFixture.Request` and
+  `HTTPClient.recording(into:base:)` to also capture `request.allHTTPHeaderFields`
+  and `request.httpBody`, and re-capture — don't fake it by hand.
+- A capture requires live OCI credentials, so it can only be run locally by a
+  developer with a configured `~/.oci/config` profile. It must never be added to
+  `.github/workflows/linux.yml`'s `UNIT_TEST_FILTER` — that list is for
+  credential-free hermetic/replay suites only.
+- Once the fixture is committed, hand off to **oci-wire-tests** to write the
+  hermetic replay suite (`Tests/Services/<Service>HermeticTests.swift`) that
+  loads it via `HTTPClient.replaying(fromFile:)` and asserts on request shape
+  and response decoding — and to add that suite's type name to
+  `UNIT_TEST_FILTER` in `.github/workflows/linux.yml` so it runs in CI.

--- a/.claude/skills/oci-capture-fixtures/SKILL.md
+++ b/.claude/skills/oci-capture-fixtures/SKILL.md
@@ -57,12 +57,13 @@ CI. Follow the existing `captureGetNamespace` pattern: build the client with a
 vars — never hardcode them):
 
 ```swift
-@Test func captureListCompartments() async throws {
+@Test("captures listCompartments from live OCI into a fixture")
+func captureListCompartments() async throws {
   let env = ProcessInfo.processInfo.environment
   guard let out = env["OCI_FIXTURE_OUT"],
         let configFile = env["OCI_CONFIG_FILE"],
         let compartmentId = env["OCI_COMPARTMENT_ID"] else {
-    print("capture skipped — set OCI_FIXTURE_OUT, OCI_CONFIG_FILE, OCI_COMPARTMENT_ID")
+    logger.info("capture skipped — set OCI_FIXTURE_OUT, OCI_CONFIG_FILE, OCI_COMPARTMENT_ID")
     return
   }
   let profile = env["OCI_PROFILE"] ?? "DEFAULT"

--- a/.claude/skills/oci-new-service-client/SKILL.md
+++ b/.claude/skills/oci-new-service-client/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: oci-new-service-client
+description: Scaffold a brand-new OCI service client in OCIKit — router enum, client struct wired to the HTTPClient seam, Codable models, error enum — following the ContainerInstances reference implementation, then instrument it with credential-free unit tests and hermetic wire tests. Use for "implement a new OCI service", "add the <X> service/client", "scaffold <X>Client", or "port <X> from the Python SDK".
+---
+
+# Scaffold a new OCI service client
+
+Build a new service the same shape as `Sources/OCIKit/services/ContainerInstances/`
+(read `ContainerInstances.swift`, `ContainerInstancesRouter.swift`, two or three
+files under `Models/`, and `ContainerInstancesErrors.swift` before starting — they
+are the ground truth for every pattern below). Replace `<Service>` with the real
+service name throughout (e.g. `Secrets`, `IAM`).
+
+## 0. Research first
+
+- Find the operation list, request/response field names, and error shapes in the
+  Python reference SDK at `~/Developer/oci-python-sdk` (`src/oci/<service>/`,
+  `models/` and `*_client.py`).
+- Cross-check paths, query params, and header names against the OCI REST API spec
+  at https://docs.oracle.com/en-us/iaas/api/#/.
+- If `<Service>` isn't yet a case in `Service` (`Sources/OCIKit/core/Region+Service.swift`),
+  add it and its host mapping, e.g. `"<service>.\(region.urlPart).oraclecloud.com"`.
+
+## 1. Create the service directory
+
+`Sources/OCIKit/services/<Service>/`:
+
+- **`<Service>Router.swift`** — a `<Service>API: API` enum, one case per operation
+  holding its path/query/header params as associated values (optionals default to
+  `nil`). Implement, exactly like `ContainerInstancesAPI`: `path: String` (switch
+  over `self`, built from a `static let version` prefix); `method: HTTPMethod`
+  (group cases by verb); `queryItems: [URLQueryItem]?` and `headers: [String:
+  String]?` (build a `[(String, String?)]` pairs array, `compactMap` out nils,
+  return `nil` if empty).
+
+- **`<Service>.swift`** — `<Service>Client: Sendable` struct holding `endpoint:
+  URL?`, `region: Region?`, `retryConfig: RetryConfig?`, `signer: Signer`,
+  `logger: Logger`, and **`httpClient: HTTPClient`**. The `init` takes `httpClient:
+  HTTPClient = .live` (defaulted, so no existing call site breaks) and resolves
+  `endpoint` from either an explicit `endpoint:` string or `region` + `Service
+  .<service>.getHost(in:)`, throwing `<Service>Error.missingRequiredParameter` if
+  neither is given. One public `async` method per operation, each following: build
+  the `<Service>API` case → `buildRequest(api:endpoint:)` → `signer.sign(&req)` →
+  `try await httpClient.data(req)` → guard the status code, throwing `<Service>Error
+  .unexpectedStatusCode` on mismatch → `JSONDecoder().decode(...)`. Route **every**
+  send site through `httpClient.data(req)`, never `URLSession.shared.data(for:)`
+  directly — that's what makes the client recordable and hermetically testable.
+  Read response headers with `http.value(forHTTPHeaderField:)` (case-insensitive; a
+  dictionary subscript on `allHeaderFields` breaks on Linux, which capitalizes
+  header names differently than Darwin). Centralize execute/encode/decode
+  boilerplate in `private` helpers, as `ContainerInstancesClient` does.
+
+- **`Models/*.swift`** — one `Codable` struct/enum per file. For fields whose wire
+  format needs translation (e.g. RFC3339 timestamps), store the raw string under a
+  private `...Raw` property with a `CodingKeys` rename and expose a computed public
+  property (see `ContainerInstance.timeCreatedRaw` / `.timeCreated`).
+
+- **`<Service>Errors.swift`** — a `<Service>Error: Error` enum: `invalidResponse`,
+  `invalidURL`, `jsonDecodingError`, `jsonEncodingError`, `missingRequiredParameter`,
+  `unexpectedStatusCode(Int, String)`, plus `LocalizedError` with an
+  `errorDescription` switch. Decode error bodies via the shared `DataBody` type,
+  not a service-specific duplicate.
+
+## 2. Naming and reuse
+
+- Prefix any type name that collides across services: `WorkRequest` →
+  `<Service>WorkRequest`. OCIKit is one module — there's no namespacing to fall
+  back on.
+- Reuse shared types instead of redefining them: `LifecycleState`, `SortOrder`,
+  `DataBody`, `RetryConfig`.
+
+## 3. Cross-platform rules
+
+Every file touching `URLRequest`/`URLSession`/`HTTPURLResponse` needs:
+```swift
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+```
+Use async `URLSession.data(for:)` / `httpClient.data(req)`, never a completion
+handler. For hashing/signing use `import Crypto` / `_CryptoExtras` (swift-crypto)
+— never `CryptoKit`, which doesn't exist on Linux.
+
+## 4. Instrument with unit tests (credential-free)
+
+Add `Tests/Services/<Service>Test.swift`, mirroring `Tests/Services/SecretsTest.swift`
+and `Tests/Services/ContainerInstancesTest.swift`. No `~/.oci/config`, no network,
+`@testable import OCIKit`. One `struct` suite per concern:
+
+- **`<Service>RouterTests`** — `.path`/`.method`/`.queryItems` (nils filtered)/
+  `.headers` for representative cases; `buildRequest(api:endpoint:)` composes the
+  full URL.
+- **`<Service>EnumsTests`** — every enum's `.rawValue` matches the OCI wire string.
+- **`<Service>ModelEncodingTests`** — `Encodable` payloads emit the right keys,
+  including nested/polymorphic objects.
+- **`<Service>ModelDecodingTests`** — `Decodable` round-trips of inline JSON
+  fixtures (nested objects, enums, dates, polymorphic discriminators).
+
+## 5. Instrument with wire tests (hand off)
+
+Wire tests exercise the client's HTTP path (request building, signing, response
+decoding) with no live network, via the `HTTPClient` seam — see
+`docs/hermetic-wire-tests.md`.
+
+1. Use skill **`oci-capture-fixtures`** to capture real `<Service>` responses into
+   `Tests/Services/Fixtures/*.json`. Review and sanitize (OCIDs, names) before
+   committing.
+2. Use skill **`oci-wire-tests`** to write `Tests/Services/<Service>HermeticTests.swift`
+   (the `StubSigner` + `actor RequestRecorder` + `makeClient` pattern from
+   `ObjectStorageHermeticTests.swift`) and a fixture-replay test via `HTTPClient
+   .replaying(fromFile:)` per `OCIFixtureReplayTests.swift`.
+
+## 6. Wire into CI
+
+Add every new suite type name to `UNIT_TEST_FILTER` in `.github/workflows/linux.yml`
+(a pipe-separated OR regex). Compiling isn't enough — an unlisted suite builds but
+never runs, so a real bug in it goes unnoticed.
+
+## 7. Verify
+
+```bash
+swift build --build-tests
+swift test --filter "<Service>RouterTests|<Service>EnumsTests|<Service>ModelEncodingTests|<Service>ModelDecodingTests|<Service>HermeticTests"
+
+# Linux — also cross-check x86_64 via GitHub CI on the PR:
+docker run --rm --platform linux/arm64 -v "$PWD":/pkg -w /pkg swift:6.2 \
+  swift test --filter "<Service>RouterTests|<Service>HermeticTests"
+```
+If SwiftLint is installed, run it and fix everything before committing.
+
+## Checklist
+
+- [ ] Operations/shapes/errors verified against the Python SDK and REST API spec.
+- [ ] `Service` enum has a host mapping for `<Service>` (if new).
+- [ ] `<Service>Router.swift`, `<Service>.swift`, `Models/*.swift`,
+      `<Service>Errors.swift` created.
+- [ ] Client has `httpClient: HTTPClient = .live`; every send site uses it.
+- [ ] Generic types prefixed per service; shared types reused, not duplicated.
+- [ ] FoundationNetworking guard, Crypto (not CryptoKit), async URLSession.
+- [ ] Unit suites added: Router/Enums/ModelEncoding/ModelDecoding.
+- [ ] Fixtures captured (`oci-capture-fixtures`) + hermetic suite written (`oci-wire-tests`).
+- [ ] New suite names added to `UNIT_TEST_FILTER` in `.github/workflows/linux.yml`.
+- [ ] `swift build --build-tests` and new suites pass on macOS and Linux (Docker + CI).

--- a/.claude/skills/oci-wire-tests/SKILL.md
+++ b/.claude/skills/oci-wire-tests/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: oci-wire-tests
+description: Write a hermetic wire-test suite for an OCI service client from committed JSON fixtures — offline replay tests that assert request-building and response-decoding with no credentials or network. Use for "write wire tests for <service>", "add replay tests", "turn these fixtures into tests", "hermetic tests for <operation>".
+---
+
+# OCI wire tests
+
+Turn committed `Tests/Services/Fixtures/*.json` fixtures into a fast, offline
+`swift-testing` suite that runs in CI and on fork PRs with **no** `~/.oci/config`,
+credentials, or network access. Full background: `docs/hermetic-wire-tests.md`.
+
+## 1. Confirm the fixtures exist
+
+Check `Tests/Services/Fixtures/` for the operation(s) you're testing (e.g.
+`listCompartments.json`). If they're missing, or the target service client
+doesn't yet take `httpClient: HTTPClient = .live` (grep the service file for
+`httpClient`), **stop and hand off to the `oci-capture-fixtures` skill** to wire
+the seam and capture the response first. Don't hand-write fixture JSON from
+guesswork — fixtures must come from a real captured response so header casing
+and field shapes are authentic. If the service client itself doesn't exist yet,
+hand off to `oci-new-service-client` instead.
+
+## 2. Create `Tests/Services/<Service>HermeticTests.swift`
+
+Follow the `ObjectStorageHermeticTests.swift` pattern exactly:
+
+```swift
+import Foundation
+import OCIKit
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// No-op signer — these tests exercise request building and response parsing,
+// not signature correctness.
+private struct StubSigner: Signer {
+  func sign(_ req: inout URLRequest) throws {}
+}
+
+struct <Service>HermeticTests {
+  private func fixtureURL(_ name: String) -> URL {
+    URL(filePath: #filePath).deletingLastPathComponent().appending(path: "Fixtures/\(name)")
+  }
+
+  // RESPONSE-DECODE test: replay a captured 200 and assert on the decoded model.
+  @Test("listCompartments decodes the array from a captured response")
+  func listCompartments() async throws {
+    let http = try HTTPClient.replaying(fromFile: fixtureURL("listCompartments.json"))
+    let client = try <Service>Client(region: .iad, signer: StubSigner(), httpClient: http)
+
+    let items = try await client.listCompartments(compartmentId: "ocid1.tenancy.oc1..EXAMPLE")
+
+    #expect(!items.isEmpty)
+    #expect(items.first?.lifecycleState == .active)
+  }
+
+  // ERROR-PATH test: a non-2xx fixture maps to the service's Error type.
+  @Test("listCompartments: non-2xx maps to <Service>Error")
+  func errorMapping() async throws {
+    let http = try HTTPClient.replaying(fromFile: fixtureURL("listCompartments_404.json"))
+    let client = try <Service>Client(region: .iad, signer: StubSigner(), httpClient: http)
+
+    await #expect(throws: <Service>Error.self) {
+      _ = try await client.listCompartments(compartmentId: "ocid1.tenancy.oc1..EXAMPLE")
+    }
+  }
+}
+```
+
+To also lock the **request shape** (method, path, query, body) instead of
+replaying a fixture, use the recorder pattern from `ObjectStorageHermeticTests.swift`
+— an `actor RequestRecorder` plus a hand-rolled `HTTPClient` closure that records
+the request and returns a canned `HTTPURLResponse`:
+
+```swift
+private actor RequestRecorder {
+  private(set) var last: URLRequest?
+  func record(_ request: URLRequest) { last = request }
+}
+
+// … inside a @Test:
+let recorder = RequestRecorder()
+let http = HTTPClient { request in
+  await recorder.record(request)
+  let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: [:])!
+  return (Data("[]".utf8), response)
+}
+let client = try <Service>Client(region: .iad, signer: StubSigner(), httpClient: http)
+_ = try await client.listCompartments(compartmentId: "ocid1.tenancy.oc1..EXAMPLE", limit: 10)
+
+let req = await recorder.last
+#expect(req?.url?.path == "/20160918/compartments")
+let query = Dictionary(uniqueKeysWithValues:
+  (URLComponents(url: req!.url!, resolvingAgainstBaseURL: false)?.queryItems ?? []).map { ($0.name, $0.value) })
+#expect(query["compartmentId"] == "ocid1.tenancy.oc1..EXAMPLE")
+#expect(query["limit"] == "10")
+```
+
+Write one response-decode test per operation you're covering, plus at least one
+error-mapping test per client (non-2xx fixtures are cheap — either capture a real
+one or hand-edit a captured fixture's `statusCode`/`bodyBase64`). Use request-shape
+tests where query params, path segments, or the body matter.
+
+## 3. Register the suite in CI
+
+CI only runs suites listed in `UNIT_TEST_FILTER` (`.github/workflows/linux.yml`),
+even though the build step compiles everything. Append the new type name to the
+pipe-separated list:
+
+```yaml
+UNIT_TEST_FILTER: >-
+  …|ObjectStorageHermeticTests|OCIFixtureReplayTests|<Service>HermeticTests
+```
+
+## 4. Run and verify
+
+```bash
+swift test --filter <Service>HermeticTests            # macOS, milliseconds
+
+# Then verify on Linux (header casing differs from Darwin — this is where
+# case-sensitive dictionary lookups on HTTPURLResponse headers break):
+docker run --rm --platform linux/arm64 -v "$PWD":/pkg -w /pkg swift:6.2 \
+  swift test --filter <Service>HermeticTests
+```
+
+Also cross-check x86_64 by opening a PR and watching the `linux.yml` matrix (it
+runs both `ubuntu-latest` and `ubuntu-24.04-arm`).
+
+## What wire tests cover — and what they don't
+
+**Covered:** the request the client builds (method, path, query, body), that the
+signing path is reached (`StubSigner` stamps a header the test can assert on),
+response decoding (JSON shapes, RFC3339 dates, enums), error mapping for non-2xx
+responses, and Linux-specific behavior like `HTTPURLResponse` header-name casing
+via `value(forHTTPHeaderField:)`.
+
+**Not covered:** whether OCI actually accepts the request — real auth, IAM
+permissions, quota, and any server-side validation. A green hermetic suite proves
+the SDK is internally consistent, not that it works against a live tenancy. Keep
+(or add) a small credential-gated live suite for that, following the self-skip
+pattern (`GenAITest`, `HealthEntityTest`) — guard on the required env var and
+return early rather than relying on `try?` alone.
+
+If fixtures go stale (OCI changes a response shape), re-run `oci-capture-fixtures`
+to refresh them; don't hand-edit captured JSON beyond sanitizing OCIDs/names or
+tweaking `statusCode` for an error-path test.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ env:
   # Regex (OR-separated) of swift-testing suite type names that are pure unit
   # tests — no ~/.oci/config, no network, no env vars. These MUST pass in CI.
   UNIT_TEST_FILTER: >-
-    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests|ResourcePrincipalSourceTests|ResourcePrincipalTokenTests|ResourcePrincipalEnvironmentTests|ResourcePrincipalSigningTests|ContainerInstancesRouterTests|ContainerInstancesEnumsTests|ContainerInstancesModelEncodingTests|ContainerInstancesModelDecodingTests|ObjectStorageHermeticTests
+    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests|ResourcePrincipalSourceTests|ResourcePrincipalTokenTests|ResourcePrincipalEnvironmentTests|ResourcePrincipalSigningTests|ContainerInstancesRouterTests|ContainerInstancesEnumsTests|ContainerInstancesModelEncodingTests|ContainerInstancesModelDecodingTests|ObjectStorageHermeticTests|OCIFixtureReplayTests
 
 jobs:
   build-and-test:

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,10 @@ postgres/oracle_fdw/**
 oracle/*.pem
 
 # Claude
-.claude/
+# (an earlier `.CL*` rule matches `.claude` case-insensitively on macOS, so we
+#  must re-include the directory before tracking just `.claude/skills/`.)
+!.claude/
+.claude/*
+!.claude/skills/
 CLAUDE.md
 

--- a/Sources/OCIKit/core/HTTPFixture.swift
+++ b/Sources/OCIKit/core/HTTPFixture.swift
@@ -1,0 +1,119 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+//
+// Record / replay support for `HTTPClient`. Capture a real OCI response once
+// (through the SDK's own transport, so the fixture preserves exactly what the
+// client sees — status, header casing, and body), commit it, and replay it in
+// fast, credential-free, offline tests.
+//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// A captured HTTP response (plus the request that produced it), serializable to
+/// JSON so it can be committed and replayed in tests.
+public struct HTTPFixture: Codable, Sendable {
+  public struct Request: Codable, Sendable {
+    public var method: String
+    public var url: String
+  }
+
+  public var request: Request
+  public var statusCode: Int
+  /// Header name → value, exactly as `HTTPURLResponse.allHeaderFields` presented
+  /// them on the capturing platform (this is where Darwin vs. Linux casing shows).
+  public var headers: [String: String]
+  /// Base64 so the fixture is safe for binary bodies (e.g. `getObject`).
+  public var bodyBase64: String
+
+  public var body: Data { Data(base64Encoded: bodyBase64) ?? Data() }
+
+  public init(request: Request, statusCode: Int, headers: [String: String], body: Data) {
+    self.request = request
+    self.statusCode = statusCode
+    self.headers = headers
+    self.bodyBase64 = body.base64EncodedString()
+  }
+
+  /// Rebuilds the `(Data, HTTPURLResponse)` pair a client method expects.
+  public func makeResponse() -> (Data, HTTPURLResponse) {
+    let url = URL(string: request.url) ?? URL(string: "https://oci.invalid")!
+    let response = HTTPURLResponse(
+      url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: headers
+    )!
+    return (body, response)
+  }
+
+  public static func load(fromFile url: URL) throws -> HTTPFixture {
+    try JSONDecoder().decode(HTTPFixture.self, from: Data(contentsOf: url))
+  }
+
+  public func save(to url: URL) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    try encoder.encode(self).write(to: url)
+  }
+}
+
+extension HTTPClient {
+  /// Wraps `base` (default ``live``) so every response is also written to
+  /// `directory` as `<METHOD>_<sanitized-path>.json`, then returned unchanged.
+  ///
+  /// Point a live client at real OCI with this transport to capture fixtures:
+  /// ```swift
+  /// let client = try ObjectStorageClient(
+  ///   region: region, signer: apiKeySigner,
+  ///   httpClient: .recording(into: fixturesDir))
+  /// _ = try await client.getNamespace()   // writes GET_n.json
+  /// ```
+  public static func recording(into directory: URL, base: HTTPClient = .live) -> HTTPClient {
+    HTTPClient { request in
+      let (data, response) = try await base.data(request)
+      if let http = response as? HTTPURLResponse {
+        var headers: [String: String] = [:]
+        for (key, value) in http.allHeaderFields {
+          if let k = key as? String, let v = value as? String { headers[k] = v }
+        }
+        let fixture = HTTPFixture(
+          request: .init(method: request.httpMethod ?? "GET", url: request.url?.absoluteString ?? ""),
+          statusCode: http.statusCode,
+          headers: headers,
+          body: data
+        )
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? fixture.save(to: directory.appending(path: fixtureFileName(for: request)))
+      }
+      return (data, response)
+    }
+  }
+
+  /// A transport that ignores the request and always returns `fixture`.
+  public static func replaying(_ fixture: HTTPFixture) -> HTTPClient {
+    HTTPClient { _ in fixture.makeResponse() }
+  }
+
+  /// Loads a committed fixture file and replays it.
+  public static func replaying(fromFile url: URL) throws -> HTTPClient {
+    replaying(try HTTPFixture.load(fromFile: url))
+  }
+}
+
+private func fixtureFileName(for request: URLRequest) -> String {
+  let method = request.httpMethod ?? "GET"
+  let segments = (request.url?.path ?? "").split(separator: "/").joined(separator: "_")
+  return "\(method)_\(segments.isEmpty ? "root" : segments).json"
+}

--- a/Sources/OCIKit/core/HTTPFixture.swift
+++ b/Sources/OCIKit/core/HTTPFixture.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2026 the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Sources/OCIKit/core/HTTPFixture.swift
+++ b/Sources/OCIKit/core/HTTPFixture.swift
@@ -53,7 +53,10 @@ public struct HTTPFixture: Codable, Sendable {
   public func makeResponse() -> (Data, HTTPURLResponse) {
     let url = URL(string: request.url) ?? URL(string: "https://oci.invalid")!
     let response = HTTPURLResponse(
-      url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: headers
+      url: url,
+      statusCode: statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: headers
     )!
     return (body, response)
   }

--- a/Tests/Services/Fixtures/getNamespace.json
+++ b/Tests/Services/Fixtures/getNamespace.json
@@ -1,0 +1,15 @@
+{
+  "bodyBase64" : "ImZyamZsZGN5bDNsYSI=",
+  "headers" : {
+    "Content-Length" : "14",
+    "Content-Type" : "application\/json",
+    "Date" : "Wed, 15 Jul 2026 07:20:19 GMT",
+    "Server" : "BaseHTTP\/0.6 Python\/3.13.13",
+    "opc-request-id" : "iad-1\/CAPTURE00000EXAMPLE\/BLOCK00000EXAMPLE"
+  },
+  "request" : {
+    "method" : "GET",
+    "url" : "http:\/\/127.0.0.1:8099\/n"
+  },
+  "statusCode" : 200
+}

--- a/Tests/Services/OCICaptureTests.swift
+++ b/Tests/Services/OCICaptureTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2026 the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Tests/Services/OCICaptureTests.swift
+++ b/Tests/Services/OCICaptureTests.swift
@@ -41,7 +41,8 @@ private struct CaptureStubSigner: Signer {
 }
 
 struct OCICaptureTests {
-  @Test func captureGetNamespace() async throws {
+  @Test("captures getNamespace from a live endpoint into a replayable fixture")
+  func captureGetNamespace() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let base = env["OCI_CAPTURE_BASE_URL"], let out = env["OCI_FIXTURE_OUT"] else {
       print("OCICaptureTests skipped — set OCI_CAPTURE_BASE_URL and OCI_FIXTURE_OUT to record.")

--- a/Tests/Services/OCICaptureTests.swift
+++ b/Tests/Services/OCICaptureTests.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+//
+// Fixture CAPTURE tool. This is the "live" half: run it once, pointed at a real
+// OCI endpoint, to record a response into a JSON fixture that hermetic tests then
+// replay. It self-skips unless configured, so it never runs in normal CI.
+//
+// Capture against real OCI:
+//   OCI_CAPTURE_BASE_URL=https://objectstorage.us-ashburn-1.oraclecloud.com \
+//   OCI_CONFIG_FILE=$HOME/.oci/config OCI_PROFILE=DEFAULT \
+//   OCI_FIXTURE_OUT=/tmp/fixtures \
+//   swift test --filter OCICaptureTests
+//
+// (With a real config the request is signed by APIKeySigner so OCI accepts it;
+// without one it falls back to a stub signer for hitting a local/mock endpoint.)
+//
+
+import Foundation
+import OCIKit
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+private struct CaptureStubSigner: Signer {
+  func sign(_ req: inout URLRequest) throws {
+    req.setValue(#"Signature version="1""#, forHTTPHeaderField: "Authorization")
+  }
+}
+
+struct OCICaptureTests {
+  @Test func captureGetNamespace() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard let base = env["OCI_CAPTURE_BASE_URL"], let out = env["OCI_FIXTURE_OUT"] else {
+      print("OCICaptureTests skipped — set OCI_CAPTURE_BASE_URL and OCI_FIXTURE_OUT to record.")
+      return
+    }
+
+    // Real OCI needs a real signature; a local mock endpoint does not.
+    let signer: Signer
+    if let configFile = env["OCI_CONFIG_FILE"] {
+      signer = try APIKeySigner(configFilePath: configFile, configName: env["OCI_PROFILE"] ?? "DEFAULT")
+    }
+    else {
+      signer = CaptureStubSigner()
+    }
+
+    let client = try ObjectStorageClient(
+      endpoint: base,
+      signer: signer,
+      httpClient: .recording(into: URL(filePath: out))
+    )
+
+    let namespace = try await client.getNamespace()
+    print("OCICaptureTests: captured getNamespace -> \"\(namespace)\"; fixture written under \(out)")
+  }
+}

--- a/Tests/Services/OCIFixtureReplayTests.swift
+++ b/Tests/Services/OCIFixtureReplayTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2026 the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Tests/Services/OCIFixtureReplayTests.swift
+++ b/Tests/Services/OCIFixtureReplayTests.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+//
+// Fixture REPLAY tests. The "hermetic" half: load a committed fixture (captured
+// once by OCICaptureTests) and drive the client against it — no credentials, no
+// network. Runs in CI and on fork PRs.
+//
+
+import Foundation
+import OCIKit
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+private struct ReplayStubSigner: Signer {
+  func sign(_ req: inout URLRequest) throws {}
+}
+
+struct OCIFixtureReplayTests {
+  // Fixtures live next to this test file; resolve via #filePath so no SwiftPM
+  // resource bundling is needed (the source tree is present at test time).
+  private func fixtureURL(_ name: String) -> URL {
+    URL(filePath: #filePath).deletingLastPathComponent().appending(path: "Fixtures/\(name)")
+  }
+
+  @Test("getNamespace replays a captured OCI response with no network")
+  func replayGetNamespace() async throws {
+    let http = try HTTPClient.replaying(fromFile: fixtureURL("getNamespace.json"))
+    let client = try ObjectStorageClient(region: .iad, signer: ReplayStubSigner(), httpClient: http)
+
+    let namespace = try await client.getNamespace()
+
+    #expect(namespace == "frjfldcyl3la")
+  }
+
+  @Test("the committed fixture round-trips through HTTPFixture")
+  func fixtureDecodes() throws {
+    let fixture = try HTTPFixture.load(fromFile: fixtureURL("getNamespace.json"))
+    #expect(fixture.statusCode == 200)
+    #expect(fixture.request.method == "GET")
+    #expect(String(data: fixture.body, encoding: .utf8) == #""frjfldcyl3la""#)
+    // The header the client reads for tracing was captured from the wire:
+    #expect(fixture.headers.keys.contains { $0.lowercased() == "opc-request-id" })
+  }
+}

--- a/docs/hermetic-wire-tests.md
+++ b/docs/hermetic-wire-tests.md
@@ -1,0 +1,209 @@
+# Hermetic wire tests: capture once, replay forever
+
+This guide shows how to add a **hermetic wire test** for an OCI operation — a test
+that runs with **no `~/.oci/config`, no credentials, and no network**, so it passes
+in CI and on fork PRs. The workflow is:
+
+1. **Capture** a real OCI response once, through the SDK's own transport.
+2. **Commit** it as a JSON fixture.
+3. **Replay** it forever in a fast, deterministic test.
+
+We'll use `IAMClient.listCompartments` as the example.
+
+The building blocks already exist:
+
+- `HTTPClient` — an injectable transport (`Sources/OCIKit/core/HTTPClient.swift`).
+  Every service client takes `httpClient: HTTPClient = .live`.
+- `HTTPClient.recording(into:)` / `.replaying(fromFile:)` and `HTTPFixture`
+  (`Sources/OCIKit/core/HTTPFixture.swift`).
+
+---
+
+## Step 1 — Wire the service client with the seam (one-time per service)
+
+`ObjectStorageClient` is already wired; `IAMClient` isn't yet. It's a three-line,
+backward-compatible change (the `.live` default means every existing caller is
+unchanged).
+
+In `Sources/OCIKit/services/Identity and Access Management/IAM.swift`:
+
+```swift
+public struct IAMClient: Sendable {
+  let endpoint: URL?
+  let signer: Signer
+  let logger: Logger
+  let httpClient: HTTPClient                                   // 1. stored property
+
+  public init(
+    region: Region? = nil, endpoint: String? = nil, signer: Signer,
+    retryConfig: RetryConfig? = nil, logger: Logger = Logger(label: "IAMClient"),
+    httpClient: HTTPClient = .live                             // 2. defaulted parameter
+  ) throws {
+    // …existing assignments…
+    self.httpClient = httpClient                              // 3. assignment
+  }
+```
+
+Then route the send sites through it — one mechanical find/replace in `IAM.swift`:
+
+```swift
+- let (data, response) = try await URLSession.shared.data(for: req)
++ let (data, response) = try await httpClient.data(req)
+```
+
+That's the whole per-service cost. Everything below is per-test.
+
+---
+
+## Step 2 — Capture a real `listCompartments` response
+
+Point the SDK at real OCI with a **recording** transport. Add a case to the gated
+capture tool (`Tests/Services/OCICaptureTests.swift`) or run a one-off:
+
+```swift
+@Test func captureListCompartments() async throws {
+  let env = ProcessInfo.processInfo.environment
+  guard let out = env["OCI_FIXTURE_OUT"],
+        let configFile = env["OCI_CONFIG_FILE"],
+        let compartmentId = env["OCI_COMPARTMENT_ID"] else {
+    print("capture skipped — set OCI_FIXTURE_OUT, OCI_CONFIG_FILE, OCI_COMPARTMENT_ID")
+    return
+  }
+  let signer = try APIKeySigner(configFilePath: configFile,
+                                configName: env["OCI_PROFILE"] ?? "DEFAULT")
+  let region = Region.from(regionId: try extractUserRegion(from: configFile) ?? "") ?? .iad
+
+  let client = try IAMClient(
+    region: region, signer: signer,
+    httpClient: .recording(into: URL(filePath: out))          // wraps .live
+  )
+  _ = try await client.listCompartments(compartmentId: compartmentId)
+  // writes <out>/GET_20160918_compartments.json
+}
+```
+
+Run it once against your tenancy:
+
+```bash
+OCI_CONFIG_FILE=$HOME/.oci/config OCI_PROFILE=DEFAULT \
+OCI_COMPARTMENT_ID=ocid1.tenancy.oc1..aaaa… \
+OCI_FIXTURE_OUT=/tmp/fixtures \
+swift test --filter OCICaptureTests
+```
+
+The recording transport captures the response **exactly as the client sees it** —
+status, body, and the true response header names OCI returns — because it records
+through the same `URLSession` the SDK uses.
+
+---
+
+## Step 3 — Commit (and sanitize) the fixture
+
+Move the captured file next to the tests and **review it before committing** — real
+compartment responses contain OCIDs and names you may not want in the repo.
+
+```bash
+cp /tmp/fixtures/GET_20160918_compartments.json \
+   Tests/Services/Fixtures/listCompartments.json
+```
+
+A trimmed, sanitized fixture:
+
+```json
+{
+  "request": { "method": "GET", "url": "https://identity.us-ashburn-1.oraclecloud.com/20160918/compartments?compartmentId=ocid1.tenancy.oc1..EXAMPLE" },
+  "statusCode": 200,
+  "headers": { "Content-Type": "application/json", "opc-request-id": "EXAMPLE" },
+  "bodyBase64": "…base64 of the JSON array of compartments…"
+}
+```
+
+> The body is base64 so binary payloads (e.g. `getObject`) work too. To edit a JSON
+> body by hand, decode `bodyBase64`, change it, re-encode.
+
+---
+
+## Step 4 — Write the hermetic replay test
+
+In `Tests/Services/IAMHermeticTests.swift` (a `no-op` signer avoids needing a key):
+
+```swift
+import Foundation
+import OCIKit
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+private struct StubSigner: Signer { func sign(_ req: inout URLRequest) throws {} }
+
+struct IAMHermeticTests {
+  private func fixtureURL(_ name: String) -> URL {
+    URL(filePath: #filePath).deletingLastPathComponent().appending(path: "Fixtures/\(name)")
+  }
+
+  @Test("listCompartments builds GET /20160918/compartments and decodes the array")
+  func listCompartments() async throws {
+    let http = try HTTPClient.replaying(fromFile: fixtureURL("listCompartments.json"))
+    let client = try IAMClient(region: .iad, signer: StubSigner(), httpClient: http)
+
+    let compartments = try await client.listCompartments(
+      compartmentId: "ocid1.tenancy.oc1..EXAMPLE",
+      limit: 10
+    )
+
+    // Response decoding
+    #expect(!compartments.isEmpty)
+    #expect(compartments.allSatisfy { $0.id.hasPrefix("ocid1.compartment") })
+    #expect(compartments.first?.lifecycleState == .active)
+  }
+}
+```
+
+Want to lock the **request shape** too (path + query), like the ObjectStorage
+tests? Capture the outgoing request with an `actor RequestRecorder` and a custom
+transport, or add a request assertion via the recorder pattern in
+`ObjectStorageHermeticTests.swift`. For `listCompartments` you'd assert:
+
+```swift
+#expect(req?.url?.path == "/20160918/compartments")
+#expect(query["compartmentId"] == "ocid1.tenancy.oc1..EXAMPLE")
+#expect(query["limit"] == "10")
+```
+
+Run it — no credentials, no network:
+
+```bash
+swift test --filter IAMHermeticTests   # passes in ~milliseconds on macOS and Linux
+```
+
+---
+
+## Step 5 — Run it in CI
+
+Add the new suite's type name to `UNIT_TEST_FILTER` in
+`.github/workflows/linux.yml` so CI executes it (the build step already compiles
+it):
+
+```yaml
+UNIT_TEST_FILTER: >-
+  …|ObjectStorageHermeticTests|OCIFixtureReplayTests|IAMHermeticTests
+```
+
+---
+
+## Notes
+
+- **Why capture instead of hand-writing JSON?** You get the true field names,
+  header casing, and shapes OCI actually returns — no guessing. Replaying on Linux
+  then exercises swift-corelibs-foundation's header handling against those real
+  names, which is how cross-platform response-parsing bugs surface.
+- **Fixtures are snapshots.** When OCI changes a response, re-capture (Step 2 is a
+  one-liner). On CI, keep `swift test` in verify mode — never auto-record.
+- **Sanitize.** Response bodies can carry OCIDs, tenancy names, and tags. The
+  fixture stores only the *response* (auth lives in the request), but still review
+  bodies before committing.
+- **What this does NOT cover.** A green replay proves the SDK builds the right
+  request and parses the response correctly — not that OCI accepts it (auth,
+  permissions, live behavior). Keep a small credential-gated live suite for that.

--- a/docs/hermetic-wire-tests.md
+++ b/docs/hermetic-wire-tests.md
@@ -61,12 +61,13 @@ Point the SDK at real OCI with a **recording** transport. Add a case to the gate
 capture tool (`Tests/Services/OCICaptureTests.swift`) or run a one-off:
 
 ```swift
-@Test func captureListCompartments() async throws {
+@Test("captures listCompartments from live OCI into a fixture")
+func captureListCompartments() async throws {
   let env = ProcessInfo.processInfo.environment
   guard let out = env["OCI_FIXTURE_OUT"],
         let configFile = env["OCI_CONFIG_FILE"],
         let compartmentId = env["OCI_COMPARTMENT_ID"] else {
-    print("capture skipped — set OCI_FIXTURE_OUT, OCI_CONFIG_FILE, OCI_COMPARTMENT_ID")
+    logger.info("capture skipped — set OCI_FIXTURE_OUT, OCI_CONFIG_FILE, OCI_COMPARTMENT_ID")
     return
   }
   let signer = try APIKeySigner(configFilePath: configFile,


### PR DESCRIPTION
**Stacked on #74 — review/merge that first.** Base is `spike/objectstorage-http-seam`, so the diff here is only the record/replay additions.

Builds on the `HTTPClient` seam so a **real** OCI response can be captured once and replayed forever in hermetic tests.

### What
- **`HTTPFixture`** (`Sources/OCIKit/core/HTTPFixture.swift`) — a Codable capture of a response (status, headers as the client saw them, base64 body) + the request.
- **`HTTPClient.recording(into:base:)`** — wraps a live transport and writes each response to `<METHOD>_<path>.json`, capturing through the SDK's own `URLSession`.
- **`HTTPClient.replaying(fromFile:)` / `.replaying(_:)`** — feed a committed fixture back.
- **`OCICaptureTests`** — a gated capture tool (self-skips unless `OCI_CAPTURE_BASE_URL` + `OCI_FIXTURE_OUT` set; signs via `APIKeySigner` when `OCI_CONFIG_FILE` is present).
- **`Tests/Services/Fixtures/getNamespace.json`** — a fixture captured over a real socket.
- **`OCIFixtureReplayTests`** — hermetic replay (wired into `UNIT_TEST_FILTER`).
- **`docs/hermetic-wire-tests.md`** — a step-by-step guide (capture → commit → replay), worked through `listCompartments`.

### Verified
Captured from a live socket on macOS; replayed green on macOS (6.3.3) and Linux (aarch64, 6.2.4).