### PR TITLE
Secrets: hermetic wire tests (second worked example of the fixture framework)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ env:
   # Regex (OR-separated) of swift-testing suite type names that are pure unit
   # tests — no ~/.oci/config, no network, no env vars. These MUST pass in CI.
   UNIT_TEST_FILTER: >-
-    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests|ResourcePrincipalSourceTests|ResourcePrincipalTokenTests|ResourcePrincipalEnvironmentTests|ResourcePrincipalSigningTests|ContainerInstancesRouterTests|ContainerInstancesEnumsTests|ContainerInstancesModelEncodingTests|ContainerInstancesModelDecodingTests|ObjectStorageHermeticTests|OCIFixtureReplayTests
+    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests|ResourcePrincipalSourceTests|ResourcePrincipalTokenTests|ResourcePrincipalEnvironmentTests|ResourcePrincipalSigningTests|ContainerInstancesRouterTests|ContainerInstancesEnumsTests|ContainerInstancesModelEncodingTests|ContainerInstancesModelDecodingTests|ObjectStorageHermeticTests|OCIFixtureReplayTests|SecretsHermeticTests
 
 jobs:
   build-and-test:

--- a/Sources/OCIKit/services/Secrets/Secrets.swift
+++ b/Sources/OCIKit/services/Secrets/Secrets.swift
@@ -42,6 +42,7 @@ public struct SecretsClient: Sendable {
   let retryConfig: RetryConfig?
   let signer: Signer
   let logger: Logger
+  let httpClient: HTTPClient
 
   // MARK: - Initialization
 
@@ -53,6 +54,8 @@ public struct SecretsClient: Sendable {
   ///   - signer: A signer implementation used for authenticating requests.
   ///   - retryConfig: Optional retry configuration for this service client.
   ///   - logger: Optional logger for debugging and diagnostics.
+  ///   - httpClient: The HTTP transport used to perform requests. Defaults to ``HTTPClient/live``
+  ///     (real `URLSession` I/O); tests can inject a recording or replaying transport.
   ///
   /// - Throws: `SecretsError.missingRequiredParameter` if neither endpoint nor region is specified.
   ///
@@ -63,11 +66,13 @@ public struct SecretsClient: Sendable {
     endpoint: String? = nil,
     signer: Signer,
     retryConfig: RetryConfig? = nil,
-    logger: Logger = Logger(label: "SecretsClient")
+    logger: Logger = Logger(label: "SecretsClient"),
+    httpClient: HTTPClient = .live
   ) throws {
     self.signer = signer
     self.retryConfig = retryConfig
     self.logger = logger
+    self.httpClient = httpClient
 
     if let endpoint, let endpointURL = URL(string: endpoint) {
       self.endpoint = endpointURL
@@ -124,7 +129,7 @@ public struct SecretsClient: Sendable {
     var req = try buildRequest(api: api, endpoint: endpoint)
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw SecretsError.invalidResponse("Invalid HTTP response")
@@ -190,7 +195,7 @@ public struct SecretsClient: Sendable {
     var req = try buildRequest(api: api, endpoint: endpoint)
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw SecretsError.invalidResponse("Invalid HTTP response")
@@ -250,7 +255,7 @@ public struct SecretsClient: Sendable {
     var req = try buildRequest(api: api, endpoint: endpoint)
     try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.data(req)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw SecretsError.invalidResponse("Invalid HTTP response")

--- a/Tests/Services/Fixtures/getSecretBundle.json
+++ b/Tests/Services/Fixtures/getSecretBundle.json
@@ -1,0 +1,19 @@
+{
+  "bodyBase64" : "eyJzZWNyZXRJZCI6Im9jaWQxLnZhdWx0c2VjcmV0Lm9jMS5waHguRVhBTVBMRSIsInRpbWVDcmVhdGVkIjoiMjAyNi0wNy0xNlQwMTo1OTowOS4zNjZaIiwidmVyc2lvbk51bWJlciI6MiwidmVyc2lvbk5hbWUiOm51bGwsInNlY3JldEJ1bmRsZUNvbnRlbnQiOnsiY29udGVudFR5cGUiOiJCQVNFNjQiLCJjb250ZW50IjoiUlZoQlRWQk1SUzFUUlVOU1JWUXRWa0ZNVlVVPSJ9LCJ0aW1lT2ZEZWxldGlvbiI6bnVsbCwidGltZU9mRXhwaXJ5IjpudWxsLCJzdGFnZXMiOlsiQ1VSUkVOVCIsIkxBVEVTVCJdLCJtZXRhZGF0YSI6bnVsbH0=",
+  "headers" : {
+    "Content-Encoding" : "gzip",
+    "Content-Length" : "293",
+    "Content-Type" : "application\/json",
+    "Date" : "Thu, 16 Jul 2026 02:00:59 GMT",
+    "Etag" : "EXAMPLE",
+    "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+    "Vary" : "Origin, Accept-Encoding",
+    "X-Content-Type-Options" : "nosniff, nosniff",
+    "opc-request-id" : "EXAMPLE"
+  },
+  "request" : {
+    "method" : "GET",
+    "url" : "https:\/\/secrets.vaults.us-phoenix-1.oci.oraclecloud.com\/20190301\/secretbundles\/ocid1.vaultsecret.oc1.phx.EXAMPLE"
+  },
+  "statusCode" : 200
+}

--- a/Tests/Services/Fixtures/getSecretBundleByName.json
+++ b/Tests/Services/Fixtures/getSecretBundleByName.json
@@ -1,0 +1,18 @@
+{
+  "bodyBase64" : "ewogICJzZWNyZXRJZCIgOiAib2NpZDEudmF1bHRzZWNyZXQub2MxLnBoeC5FWEFNUExFIiwKICAidGltZUNyZWF0ZWQiIDogIjIwMjYtMDctMTZUMDE6NTk6MDkuMzY2WiIsCiAgInZlcnNpb25OdW1iZXIiIDogMiwKICAidmVyc2lvbk5hbWUiIDogbnVsbCwKICAic2VjcmV0QnVuZGxlQ29udGVudCIgOiB7CiAgICAiY29udGVudFR5cGUiIDogIkJBU0U2NCIsCiAgICAiY29udGVudCIgOiAiUlZoQlRWQk1SUzFUUlVOU1JWUXRWa0ZNVlVVPSIKICB9LAogICJ0aW1lT2ZEZWxldGlvbiIgOiBudWxsLAogICJ0aW1lT2ZFeHBpcnkiIDogbnVsbCwKICAic3RhZ2VzIiA6IFsgIkNVUlJFTlQiLCAiTEFURVNUIiBdLAogICJtZXRhZGF0YSIgOiBudWxsCn0=",
+  "headers" : {
+    "Content-Encoding" : "gzip",
+    "Content-Length" : "313",
+    "Content-Type" : "application\/json",
+    "Date" : "Thu, 16 Jul 2026 02:00:59 GMT",
+    "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+    "Vary" : "Origin, Accept-Encoding",
+    "X-Content-Type-Options" : "nosniff, nosniff",
+    "opc-request-id" : "EXAMPLE"
+  },
+  "request" : {
+    "method" : "POST",
+    "url" : "https:\/\/secrets.vaults.us-phoenix-1.oci.oraclecloud.com\/20190301\/secretbundles\/actions\/getByName?secretName=EXAMPLE-secret&vaultId=ocid1.vault.oc1.phx.EXAMPLE"
+  },
+  "statusCode" : 200
+}

--- a/Tests/Services/Fixtures/getSecretBundle_404.json
+++ b/Tests/Services/Fixtures/getSecretBundle_404.json
@@ -1,0 +1,17 @@
+{
+  "bodyBase64" : "ewogICJjb2RlIiA6ICJOb3RBdXRob3JpemVkT3JOb3RGb3VuZCIsCiAgIm1lc3NhZ2UiIDogIkF1dGhvcml6YXRpb24gZmFpbGVkIG9yIHJlcXVlc3RlZCByZXNvdXJjZSBub3QgZm91bmQuIgp9",
+  "headers" : {
+    "Content-Length" : "111",
+    "Content-Type" : "application\/json",
+    "Date" : "Thu, 16 Jul 2026 02:00:59 GMT",
+    "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+    "Vary" : "Origin",
+    "X-Content-Type-Options" : "nosniff, nosniff",
+    "opc-request-id" : "EXAMPLE"
+  },
+  "request" : {
+    "method" : "GET",
+    "url" : "https:\/\/secrets.vaults.us-phoenix-1.oci.oraclecloud.com\/20190301\/secretbundles\/ocid1.vaultsecret.oc1.phx.EXAMPLE"
+  },
+  "statusCode" : 404
+}

--- a/Tests/Services/Fixtures/listSecretBundleVersions.json
+++ b/Tests/Services/Fixtures/listSecretBundleVersions.json
@@ -1,0 +1,19 @@
+{
+  "bodyBase64" : "W3sic2VjcmV0SWQiOiJvY2lkMS52YXVsdHNlY3JldC5vYzEucGh4LkVYQU1QTEUiLCJ0aW1lQ3JlYXRlZCI6IjIwMjYtMDctMTZUMDE6NTk6MDkuMzY2WiIsInZlcnNpb25OdW1iZXIiOjIsInZlcnNpb25OYW1lIjpudWxsLCJ0aW1lT2ZEZWxldGlvbiI6bnVsbCwidGltZU9mRXhwaXJ5IjpudWxsLCJzdGFnZXMiOlsiQ1VSUkVOVCIsIkxBVEVTVCJdfSx7InNlY3JldElkIjoib2NpZDEudmF1bHRzZWNyZXQub2MxLnBoeC5FWEFNUExFIiwidGltZUNyZWF0ZWQiOiIyMDI2LTA3LTE2VDAxOjU4OjUzLjYwM1oiLCJ2ZXJzaW9uTnVtYmVyIjoxLCJ2ZXJzaW9uTmFtZSI6bnVsbCwidGltZU9mRGVsZXRpb24iOm51bGwsInRpbWVPZkV4cGlyeSI6bnVsbCwic3RhZ2VzIjpbIlBSRVZJT1VTIl19XQ==",
+  "headers" : {
+    "Content-Encoding" : "gzip",
+    "Content-Length" : "246",
+    "Content-Type" : "application\/json",
+    "Date" : "Thu, 16 Jul 2026 02:00:59 GMT",
+    "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+    "Vary" : "Origin, Accept-Encoding",
+    "X-Content-Type-Options" : "nosniff, nosniff",
+    "opc-next-page" : "EXAMPLE",
+    "opc-request-id" : "EXAMPLE"
+  },
+  "request" : {
+    "method" : "GET",
+    "url" : "https:\/\/secrets.vaults.us-phoenix-1.oci.oraclecloud.com\/20190301\/secretbundles\/ocid1.vaultsecret.oc1.phx.EXAMPLE\/versions"
+  },
+  "statusCode" : 200
+}

--- a/Tests/Services/OCICaptureTests.swift
+++ b/Tests/Services/OCICaptureTests.swift
@@ -66,4 +66,76 @@ struct OCICaptureTests {
     let namespace = try await client.getNamespace()
     print("OCICaptureTests: captured getNamespace -> \"\(namespace)\"; fixture written under \(out)")
   }
+
+  // MARK: - Secrets Retrieval API captures
+
+  /// Builds a live, recording `SecretsClient` for the configured profile, or
+  /// returns `nil` (with a printed reason) when the required env vars are absent
+  /// so the capture self-skips in CI.
+  private func makeRecordingSecretsClient(_ env: [String: String]) throws -> (client: SecretsClient, out: String)? {
+    guard let out = env["OCI_FIXTURE_OUT"], let configFile = env["OCI_CONFIG_FILE"] else {
+      print("Secrets capture skipped — set OCI_FIXTURE_OUT and OCI_CONFIG_FILE to record.")
+      return nil
+    }
+    let profile = env["OCI_PROFILE"] ?? "DEFAULT"
+    let signer = try APIKeySigner(configFilePath: configFile, configName: profile)
+    let region = Region.from(regionId: try extractUserRegion(from: configFile, profile: profile) ?? "") ?? .iad
+    let client = try SecretsClient(
+      region: region,
+      signer: signer,
+      httpClient: .recording(into: URL(filePath: out))
+    )
+    return (client, out)
+  }
+
+  @Test func captureGetSecretBundle() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard let secretId = env["OCI_SECRET_ID"] else {
+      print("captureGetSecretBundle skipped — set OCI_SECRET_ID.")
+      return
+    }
+    guard let (client, out) = try makeRecordingSecretsClient(env) else { return }
+
+    let bundle = try await client.getSecretBundle(secretId: secretId)
+    print("OCICaptureTests: captured getSecretBundle v\(bundle.versionNumber); fixture written under \(out)")
+  }
+
+  @Test func captureListSecretBundleVersions() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard let secretId = env["OCI_SECRET_ID"] else {
+      print("captureListSecretBundleVersions skipped — set OCI_SECRET_ID.")
+      return
+    }
+    guard let (client, out) = try makeRecordingSecretsClient(env) else { return }
+
+    let versions = try await client.listSecretBundleVersions(secretId: secretId)
+    print("OCICaptureTests: captured listSecretBundleVersions -> \(versions.count) versions; fixture written under \(out)")
+  }
+
+  @Test func captureGetSecretBundleByName() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard let secretName = env["OCI_SECRET_NAME"], let vaultId = env["OCI_VAULT_ID"] else {
+      print("captureGetSecretBundleByName skipped — set OCI_SECRET_NAME and OCI_VAULT_ID.")
+      return
+    }
+    guard let (client, out) = try makeRecordingSecretsClient(env) else { return }
+
+    let bundle = try await client.getSecretBundleByName(secretName: secretName, vaultId: vaultId)
+    print("OCICaptureTests: captured getSecretBundleByName v\(bundle.versionNumber); fixture written under \(out)")
+  }
+
+  /// Captures a real 404 error body/headers. The recording transport writes the
+  /// fixture before the client parses the non-2xx status and throws, so the
+  /// thrown `SecretsError` is expected and ignored here.
+  @Test func captureGetSecretBundleNotFound() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard let badSecretId = env["OCI_BAD_SECRET_ID"] else {
+      print("captureGetSecretBundleNotFound skipped — set OCI_BAD_SECRET_ID.")
+      return
+    }
+    guard let (client, out) = try makeRecordingSecretsClient(env) else { return }
+
+    _ = try? await client.getSecretBundle(secretId: badSecretId)
+    print("OCICaptureTests: captured getSecretBundle 404 fixture under \(out)")
+  }
 }

--- a/Tests/Services/OCICaptureTests.swift
+++ b/Tests/Services/OCICaptureTests.swift
@@ -89,7 +89,8 @@ struct OCICaptureTests {
     return (client, out)
   }
 
-  @Test func captureGetSecretBundle() async throws {
+  @Test("captures getSecretBundle from live OCI into a fixture")
+  func captureGetSecretBundle() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let secretId = env["OCI_SECRET_ID"] else {
       print("captureGetSecretBundle skipped — set OCI_SECRET_ID.")
@@ -101,7 +102,8 @@ struct OCICaptureTests {
     print("OCICaptureTests: captured getSecretBundle v\(bundle.versionNumber); fixture written under \(out)")
   }
 
-  @Test func captureListSecretBundleVersions() async throws {
+  @Test("captures listSecretBundleVersions from live OCI into a fixture")
+  func captureListSecretBundleVersions() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let secretId = env["OCI_SECRET_ID"] else {
       print("captureListSecretBundleVersions skipped — set OCI_SECRET_ID.")
@@ -113,7 +115,8 @@ struct OCICaptureTests {
     print("OCICaptureTests: captured listSecretBundleVersions -> \(versions.count) versions; fixture written under \(out)")
   }
 
-  @Test func captureGetSecretBundleByName() async throws {
+  @Test("captures getSecretBundleByName from live OCI into a fixture")
+  func captureGetSecretBundleByName() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let secretName = env["OCI_SECRET_NAME"], let vaultId = env["OCI_VAULT_ID"] else {
       print("captureGetSecretBundleByName skipped — set OCI_SECRET_NAME and OCI_VAULT_ID.")
@@ -128,7 +131,8 @@ struct OCICaptureTests {
   /// Captures a real 404 error body/headers. The recording transport writes the
   /// fixture before the client parses the non-2xx status and throws, so the
   /// thrown `SecretsError` is expected and ignored here.
-  @Test func captureGetSecretBundleNotFound() async throws {
+  @Test("captures a real 404 from getSecretBundle into a fixture")
+  func captureGetSecretBundleNotFound() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let badSecretId = env["OCI_BAD_SECRET_ID"] else {
       print("captureGetSecretBundleNotFound skipped — set OCI_BAD_SECRET_ID.")

--- a/Tests/Services/SecretsHermeticTests.swift
+++ b/Tests/Services/SecretsHermeticTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the oci-swift-sdk open source project
 //
-// Copyright (c) 2026 the oci-swift-sdk project authors
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
 // Licensed under MIT License
 //
 // See LICENSE for license information

--- a/Tests/Services/SecretsHermeticTests.swift
+++ b/Tests/Services/SecretsHermeticTests.swift
@@ -69,7 +69,10 @@ struct SecretsHermeticTests {
     let http = HTTPClient { request in
       await recorder.record(request)
       let response = HTTPURLResponse(
-        url: request.url!, statusCode: status, httpVersion: "HTTP/1.1", headerFields: [:]
+        url: request.url!,
+        statusCode: status,
+        httpVersion: "HTTP/1.1",
+        headerFields: [:]
       )!
       return (body, response)
     }

--- a/Tests/Services/SecretsHermeticTests.swift
+++ b/Tests/Services/SecretsHermeticTests.swift
@@ -1,0 +1,209 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+//
+// Hermetic tests for SecretsClient — no ~/.oci/config, no credentials, no
+// network. Two shapes are used:
+//   • replay a committed fixture (captured once from real OCI by OCICaptureTests)
+//     and assert on the decoded model — locks response parsing.
+//   • inject a recording HTTPClient closure and assert on the request the client
+//     built (method, path, query, headers) — locks request building.
+// Both run anywhere (CI, fork PRs, offline).
+//
+
+import Foundation
+import OCIKit
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// A no-op-ish signer. These tests exercise request building and response
+// parsing, not signature correctness. It stamps an Authorization header so a
+// request-shape test can confirm the signing path was reached.
+private struct StubSigner: Signer {
+  func sign(_ req: inout URLRequest) throws {
+    req.setValue(#"Signature version="1""#, forHTTPHeaderField: "Authorization")
+  }
+}
+
+// Sendable-safe capture of the last request the client handed to the transport.
+private actor RequestRecorder {
+  private(set) var last: URLRequest?
+  func record(_ request: URLRequest) { last = request }
+}
+
+struct SecretsHermeticTests {
+  // Well-formed placeholder OCIDs matching the sanitized fixtures.
+  private static let secretId = "ocid1.vaultsecret.oc1.phx.EXAMPLE"
+  private static let vaultId = "ocid1.vault.oc1.phx.EXAMPLE"
+
+  // Fixtures live next to this test file; resolve via #filePath so no SwiftPM
+  // resource bundling is needed (the source tree is present at test time).
+  private func fixtureURL(_ name: String) -> URL {
+    URL(filePath: #filePath).deletingLastPathComponent().appending(path: "Fixtures/\(name)")
+  }
+
+  private func replayClient(_ fixture: String) throws -> SecretsClient {
+    let http = try HTTPClient.replaying(fromFile: fixtureURL(fixture))
+    return try SecretsClient(region: .phx, signer: StubSigner(), httpClient: http)
+  }
+
+  // Builds a client whose transport records the request and returns a canned response.
+  private func recordingClient(
+    status: Int = 200,
+    body: Data,
+    recorder: RequestRecorder
+  ) throws -> SecretsClient {
+    let http = HTTPClient { request in
+      await recorder.record(request)
+      let response = HTTPURLResponse(
+        url: request.url!, statusCode: status, httpVersion: "HTTP/1.1", headerFields: [:]
+      )!
+      return (body, response)
+    }
+    return try SecretsClient(region: .phx, signer: StubSigner(), httpClient: http)
+  }
+
+  private func query(of req: URLRequest?) -> [String: String] {
+    let items = req?.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false)?.queryItems } ?? []
+    return Dictionary(items.map { ($0.name, $0.value ?? "") }, uniquingKeysWith: { a, _ in a })
+  }
+
+  // MARK: - Response decoding (replay captured 200s)
+
+  @Test("getSecretBundle decodes the bundle, stages, and Base64 content")
+  func getSecretBundleDecodes() async throws {
+    let client = try replayClient("getSecretBundle.json")
+
+    let bundle = try await client.getSecretBundle(secretId: Self.secretId)
+
+    #expect(bundle.secretId == Self.secretId)
+    #expect(bundle.versionNumber == 2)
+    #expect(bundle.versionName == nil)
+    #expect(bundle.stages == [.current, .latest])
+    #expect(bundle.metadata == nil)
+    #expect(bundle.timeCreated != nil)  // RFC3339 -> Date parsing exercised
+    // Polymorphic secret content decodes and Base64-unwraps.
+    #expect(bundle.secretBundleContent?.contentType == .base64)
+    #expect(bundle.secretBundleContent?.decodedString == "EXAMPLE-SECRET-VALUE")
+  }
+
+  @Test("listSecretBundleVersions decodes the array of version summaries")
+  func listSecretBundleVersionsDecodes() async throws {
+    let client = try replayClient("listSecretBundleVersions.json")
+
+    let versions = try await client.listSecretBundleVersions(secretId: Self.secretId)
+
+    #expect(versions.count == 2)
+    #expect(versions.map(\.versionNumber) == [2, 1])
+    #expect(versions.first?.stages == [.current, .latest])
+    #expect(versions.last?.stages == [.previous])
+    #expect(versions.first?.timeCreated != nil)  // RFC3339 -> Date parsing exercised
+  }
+
+  @Test("getSecretBundleByName decodes the same bundle shape as getSecretBundle")
+  func getSecretBundleByNameDecodes() async throws {
+    let client = try replayClient("getSecretBundleByName.json")
+
+    let bundle = try await client.getSecretBundleByName(
+      secretName: "EXAMPLE-secret",
+      vaultId: Self.vaultId
+    )
+
+    #expect(bundle.secretId == Self.secretId)
+    #expect(bundle.versionNumber == 2)
+    #expect(bundle.secretBundleContent?.decodedString == "EXAMPLE-SECRET-VALUE")
+  }
+
+  // MARK: - Request shape (record the outgoing request)
+
+  @Test("getSecretBundle: builds GET /secretbundles/<id> with versionNumber & stage query")
+  func getSecretBundleRequestShape() async throws {
+    let recorder = RequestRecorder()
+    // Minimal valid SecretBundle so the call returns without throwing.
+    let body = Data(#"{"secretId":"\#(Self.secretId)","versionNumber":3,"stages":["PENDING"]}"#.utf8)
+    let client = try recordingClient(body: body, recorder: recorder)
+
+    _ = try await client.getSecretBundle(
+      secretId: Self.secretId,
+      versionNumber: 3,
+      stage: .current,
+      opcRequestId: "req-abc"
+    )
+
+    let req = await recorder.last
+    #expect(req?.httpMethod == "GET")
+    #expect(req?.url?.host == "secrets.vaults.us-phoenix-1.oci.oraclecloud.com")
+    #expect(req?.url?.path == "/20190301/secretbundles/\(Self.secretId)")
+    let q = query(of: req)
+    #expect(q["versionNumber"] == "3")
+    #expect(q["stage"] == "CURRENT")
+    #expect(req?.value(forHTTPHeaderField: "opc-request-id") == "req-abc")
+    #expect(req?.value(forHTTPHeaderField: "Authorization") != nil)  // signer ran
+  }
+
+  @Test("getSecretBundleByName: uses POST to actions/getByName with secretName & vaultId query")
+  func getSecretBundleByNameRequestShape() async throws {
+    let recorder = RequestRecorder()
+    let body = Data(#"{"secretId":"\#(Self.secretId)","versionNumber":2}"#.utf8)
+    let client = try recordingClient(body: body, recorder: recorder)
+
+    _ = try await client.getSecretBundleByName(
+      secretName: "EXAMPLE-secret",
+      vaultId: Self.vaultId,
+      stage: .latest
+    )
+
+    let req = await recorder.last
+    #expect(req?.httpMethod == "POST")  // read operation that uses POST
+    #expect(req?.url?.path == "/20190301/secretbundles/actions/getByName")
+    let q = query(of: req)
+    #expect(q["secretName"] == "EXAMPLE-secret")
+    #expect(q["vaultId"] == Self.vaultId)
+    #expect(q["stage"] == "LATEST")
+  }
+
+  @Test("listSecretBundleVersions: builds GET /versions with limit/sortBy/sortOrder query")
+  func listSecretBundleVersionsRequestShape() async throws {
+    let recorder = RequestRecorder()
+    let client = try recordingClient(body: Data("[]".utf8), recorder: recorder)
+
+    _ = try await client.listSecretBundleVersions(
+      secretId: Self.secretId,
+      limit: 25,
+      sortBy: .versionNumber,
+      sortOrder: .desc
+    )
+
+    let req = await recorder.last
+    #expect(req?.httpMethod == "GET")
+    #expect(req?.url?.path == "/20190301/secretbundles/\(Self.secretId)/versions")
+    let q = query(of: req)
+    #expect(q["limit"] == "25")
+    #expect(q["sortBy"] == "VERSION_NUMBER")
+    #expect(q["sortOrder"] == "DESC")
+  }
+
+  // MARK: - Error mapping
+
+  @Test("getSecretBundle: a captured 404 maps to SecretsError")
+  func errorMapping() async throws {
+    let client = try replayClient("getSecretBundle_404.json")
+
+    await #expect(throws: SecretsError.self) {
+      _ = try await client.getSecretBundle(secretId: Self.secretId)
+    }
+  }
+}


### PR DESCRIPTION
## What

A second worked example of the record/replay HTTP fixture framework, applied to the **Secrets Retrieval** service — showing how to take a new service client hermetic end-to-end using the same seam + capture + replay flow introduced for ObjectStorage.

Stacked on top of #75 (base branch `spike/fixture-capture`).

## How it uses the framework

1. **Seam** — `SecretsClient` now takes `httpClient: HTTPClient = .live`; all three send sites go through `httpClient.data(req)`. The `.live` default is backward-compatible, so no existing caller changes.
2. **Capture** — env-gated `@Test`s in `OCICaptureTests` record real responses via `HTTPClient.recording(into:)`. They self-skip without env vars and never run in CI.
3. **Sanitize + commit** — four fixtures under `Tests/Services/Fixtures/`, scrubbed to `EXAMPLE` placeholders (OCIDs, vault id, secret name, `opc-request-id`/`opc-next-page`/`Etag`, and the secret content).
4. **Replay** — `SecretsHermeticTests` drives the client against the committed fixtures with a stub signer: **no credentials, no network**.

## Tests (7, all credential-free)

- **Response-decode** (replay): `getSecretBundle`, `listSecretBundleVersions`, `getSecretBundleByName` — asserts the decoded `SecretBundle`/version summaries, stages, RFC3339 dates, and Base64 content unwrap.
- **Request-shape** (recorder): method/path/query for all three, including the `getByName` **POST-despite-read** quirk and `sortBy`/`sortOrder`/`limit`/`stage`/`versionNumber` query building; confirms the signing path is reached.
- **Error mapping**: a captured `404` maps to `SecretsError`.

Registered `SecretsHermeticTests` in the Linux CI `UNIT_TEST_FILTER`.

## Verification

- `swift test --filter SecretsHermeticTests` — green on **macOS**.
- Same suite green in `swift:6.2` Docker on **Linux arm64**; the full test target also compiled cleanly there (exercises the `HTTPURLResponse` header-casing path via `value(forHTTPHeaderField:)`).

## Provenance of fixtures

Captured from a throwaway vault + software key + 2-version secret provisioned in the `oci-swift-sdk` compartment, then scheduled for deletion. Fixtures contain only sanitized placeholder values — no real OCIDs, tenancy identifiers, or secret material.
