### PR TITLE
Tests: use the shared OCIKit logger instead of print

### DIFF
--- a/Sources/OCIKit/services/generativeai/GenerateText.swift
+++ b/Sources/OCIKit/services/generativeai/GenerateText.swift
@@ -294,7 +294,6 @@ public struct GenerateText {
     let (data, _) = try await URLSession.shared.data(for: urlRequest)
     let debugString = String(data: data, encoding: .utf8) ?? ""
     logger.debug("http response: \(debugString)")
-    print("http response: \(debugString)")
     let decoder = JSONDecoder()
     let response = try decoder.decode(GenerateTextResult.self, from: data)
     return response

--- a/Tests/Linux/ObjectStorageTestOnLinux.swift
+++ b/Tests/Linux/ObjectStorageTestOnLinux.swift
@@ -47,7 +47,7 @@ struct ObjectStorageTestOnLinux {
     let namespace = try await sut.getNamespace()
 
     // Prints the namespace
-    print("The current namespace is: \(namespace)")
+    logger.info("The current namespace is: \(namespace)")
     #expect(!namespace.isEmpty, "Namespace should not be empty")
   }
 
@@ -107,7 +107,7 @@ struct ObjectStorageTestOnLinux {
     // Print objects
     for object in originalObjects.objects {
       if let timeCreated = object.timeCreated, let size = object.size {
-        print("ID: \(object.id ), Name: \(object.name), Size: \(size), Created: \(timeCreated)")
+        logger.info("ID: \(object.id ), Name: \(object.name), Size: \(size), Created: \(timeCreated)")
       }
     }
     #expect(!originalObjects.objects.isEmpty, "Expected non-empty object list after API execution")
@@ -153,7 +153,7 @@ struct ObjectStorageTestOnLinux {
 
     // Lists all buckets in the compartment
     for bucket in listOfBuckets {
-      print(bucket.name)
+      logger.info("\(bucket.name)")
     }
     #expect(
       listOfBuckets.count > 0,

--- a/Tests/Linux/PutObjectHeaderCasingDiagnostics.swift
+++ b/Tests/Linux/PutObjectHeaderCasingDiagnostics.swift
@@ -79,8 +79,8 @@ struct PutObjectHeaderCasingDiagnostics {
     let client = try ObjectStorageClient(region: region, signer: signer)
     let namespace = try await client.getNamespace()
 
-    print("\n========== [\(platform)] PutObject header-casing diagnostic ==========")
-    print("namespace: \(namespace)  bucket: \(bucketName)")
+    logger.info("\n========== [\(platform)] PutObject header-casing diagnostic ==========")
+    logger.info("namespace: \(namespace)  bucket: \(bucketName)")
 
     let objectName = "linux-header-casing-test.txt"
     let body = Data("Hello from \(platform)".utf8)
@@ -97,9 +97,9 @@ struct PutObjectHeaderCasingDiagnostics {
 
     let (data, response) = try await URLSession.shared.data(for: req)
     let http = try #require(response as? HTTPURLResponse)
-    print("HTTP status: \(http.statusCode)  (200 == server stored the object)")
+    logger.info("HTTP status: \(http.statusCode)  (200 == server stored the object)")
     if http.statusCode != 200 {
-      print("response body: \(String(data: data, encoding: .utf8) ?? "<non-utf8>")")
+      logger.info("response body: \(String(data: data, encoding: .utf8) ?? "<non-utf8>")")
     }
 
     // Build the OLD case-sensitive dictionary to show how the previous code failed.
@@ -107,21 +107,21 @@ struct PutObjectHeaderCasingDiagnostics {
       if let k = pair.key as? String, let v = pair.value as? String { acc[k] = v }
     }
 
-    print("--- allHeaderFields keys, verbatim (\(dict.count)) ---")
-    for k in dict.keys.sorted() { print("    '\(k)' = \(dict[k]!)") }
+    logger.info("--- allHeaderFields keys, verbatim (\(dict.count)) ---")
+    for k in dict.keys.sorted() { logger.info("    '\(k)' = \(dict[k]!)") }
 
     let sdkKeys = ["etag", "last-modified", "opc-content-md5", "opc-request-id", "version-id"]
-    print("--- OLD case-sensitive dict lookups (what the bug did) ---")
+    logger.info("--- OLD case-sensitive dict lookups (what the bug did) ---")
     for key in sdkKeys {
-      print("    dict[\"\(key)\"] -> \(dict[key] != nil ? "FOUND" : "nil  <-- guard failed here")")
+      logger.info("    dict[\"\(key)\"] -> \(dict[key] != nil ? "FOUND" : "nil  <-- guard failed here")")
     }
 
-    print("--- NEW value(forHTTPHeaderField:) lookups (the fix) ---")
+    logger.info("--- NEW value(forHTTPHeaderField:) lookups (the fix) ---")
     for key in sdkKeys {
       let v = http.value(forHTTPHeaderField: key)
-      print("    value(\"\(key)\") -> \(v != nil ? "FOUND" : "nil")")
+      logger.info("    value(\"\(key)\") -> \(v != nil ? "FOUND" : "nil")")
     }
-    print("======================================================================\n")
+    logger.info("======================================================================\n")
 
     #expect(http.statusCode == 200, "The upload itself must succeed (server returns 200)")
   }
@@ -143,12 +143,12 @@ struct PutObjectHeaderCasingDiagnostics {
         objectName: "linux-putobject-repro.txt",
         putObjectBody: Data("repro".utf8)
       )
-      print("=== [\(platform)] putObject returned normally (no error) ===")
+      logger.info("=== [\(platform)] putObject returned normally (no error) ===")
     }
     catch {
-      print("=== [\(platform)] putObject THREW after a successful upload ===")
-      print("    error: \(error)")
-      print("    localizedDescription: \(error.localizedDescription)")
+      logger.info("=== [\(platform)] putObject THREW after a successful upload ===")
+      logger.info("    error: \(error)")
+      logger.info("    localizedDescription: \(error.localizedDescription)")
       Issue.record("putObject threw despite the object being uploaded: \(error.localizedDescription)")
     }
   }

--- a/Tests/OCIKit/InstancePrincipalTest.swift
+++ b/Tests/OCIKit/InstancePrincipalTest.swift
@@ -39,12 +39,12 @@ struct InstancePrincipalObjectStorageTest {
 
   @Test func getNamespace_withInstancePrincipalSigner() async throws {
     guard let regionRaw = await fetchIMDSRegion() else {
-      print("Skipping Instance Principal test: IMDS region unavailable (not running on OCI instance?)")
+      logger.info("Skipping Instance Principal test: IMDS region unavailable (not running on OCI instance?)")
       return
     }
 
     guard let region = Region.from(regionId: regionRaw) else {
-      print("Skipping Instance Principal test: IMDS returned unsupported or short region '\(regionRaw)'; Region enum expects long-form (e.g. us-phoenix-1).")
+      logger.info("Skipping Instance Principal test: IMDS returned unsupported or short region '\(regionRaw)'; Region enum expects long-form (e.g. us-phoenix-1).")
       return
     }
 
@@ -52,7 +52,7 @@ struct InstancePrincipalObjectStorageTest {
     let client = try ObjectStorageClient(region: region, signer: signer)
 
     let namespace = try await client.getNamespace()
-    print("Namespace (Instance Principal): \(namespace)")
+    logger.info("Namespace (Instance Principal): \(namespace)")
     #expect(!namespace.isEmpty)
   }
 }

--- a/Tests/OCIKit/OCIKitTests.swift
+++ b/Tests/OCIKit/OCIKitTests.swift
@@ -40,7 +40,7 @@ final class OCIKitTests: XCTestCase {
 
     var req = URLRequest(url: URL(string: "https://objectstorage.\(userRegion).oraclecloud.com/n")!)
     try signer.sign(&req)
-    print(">>> All Headers: >>> \n\(req.allHTTPHeaderFields ?? [:])\n>>>>>>>>\n")
+    logger.info(">>> All Headers: >>> \n\(req.allHTTPHeaderFields ?? [:])\n>>>>>>>>\n")
 
     let (data, response) = try await URLSession.shared.data(for: req)
 
@@ -52,6 +52,6 @@ final class OCIKitTests: XCTestCase {
     XCTAssertEqual(httpResponse.statusCode, 200, "Expected HTTP 200 OK, got \(httpResponse.statusCode)")
 
     let responseBody = String(data: data, encoding: .utf8)
-    print("Response: \(responseBody ?? "<no body>")")
+    logger.info("Response: \(responseBody ?? "<no body>")")
   }
 }

--- a/Tests/Services/GenAITest.swift
+++ b/Tests/Services/GenAITest.swift
@@ -24,7 +24,7 @@ struct GenAITest {
       let compartment = ProcessInfo.processInfo.environment["GENAI_COMPARTMENT_OCID"], !compartment.isEmpty,
       let modelId = ProcessInfo.processInfo.environment["GENAI_COHERE_MODEL_OCID"], !modelId.isEmpty
     else {
-      print("testGenAICohere not configured")
+      logger.info("testGenAICohere not configured")
       return
     }
     let signer = try APIKeySigner(configFilePath: ociConfigFilePath, configName: ociProfileName)
@@ -49,7 +49,7 @@ struct GenAITest {
       servingMode: GenerateText.OnDemandServingMode(modelId: modelId)
     )
     let response = try await getText.getCompletion(req)
-    print("reponse: \(response)")
+    logger.info("reponse: \(response)")
   }
 
   @Test func testGenAILlama() async throws {
@@ -57,7 +57,7 @@ struct GenAITest {
       let compartment = ProcessInfo.processInfo.environment["GENAI_COMPARTMENT_OCID"], !compartment.isEmpty,
       let modelId = ProcessInfo.processInfo.environment["GENAI_LLAMA_MODEL_OCID"], !modelId.isEmpty
     else {
-      print("testGenAILlama not configured")
+      logger.info("testGenAILlama not configured")
       return
     }
     let signer = try APIKeySigner(configFilePath: ociConfigFilePath, configName: ociProfileName)
@@ -81,6 +81,6 @@ struct GenAITest {
       servingMode: GenerateText.OnDemandServingMode(modelId: modelId)
     )
     let response = try await getText.getCompletion(req)
-    print("reponse: \(response)")
+    logger.info("reponse: \(response)")
   }
 }

--- a/Tests/Services/HealthEntityTest.swift
+++ b/Tests/Services/HealthEntityTest.swift
@@ -21,10 +21,10 @@ struct HealthEntityTest {
 
   @Test func testHealthNER() async throws {
     guard let endpoint = ProcessInfo.processInfo.environment["HEALTH_NER_ENDPOINT"], !endpoint.isEmpty else {
-      print("testHealthNER not configured")
+      logger.info("testHealthNER not configured")
       return
     }
-    print("ociProfileName: \(ociProfileName)")
+    logger.info("ociProfileName: \(ociProfileName)")
     let signer = try APIKeySigner(configFilePath: ociConfigFilePath, configName: ociProfileName)
     let healthNER = BatchDetectHealthEntity(region: .iad, signer: signer)
     let req = BatchDetectHealthEntity.BatchDetectHealthEntityDetails(
@@ -34,6 +34,6 @@ struct HealthEntityTest {
       isDetectRelationships: true
     )
     let response = try await healthNER.getHealthEntities(req)
-    print("reponse: \(response)")
+    logger.info("reponse: \(response)")
   }
 }

--- a/Tests/Services/IAMTest.swift
+++ b/Tests/Services/IAMTest.swift
@@ -96,7 +96,7 @@ struct IAMTest {
 
     // Print created compartment
     if let compartment = createdCompartment {
-      print("Compartment created: \(compartment.name)\n with ID: \(compartment.id)")
+      logger.info("Compartment created: \(compartment.name)\n with ID: \(compartment.id)")
     }
     #expect(createdCompartment != nil, "createdCompartment should not be nil")
   }
@@ -138,7 +138,7 @@ struct IAMTest {
 
     // Print compartment name
     if let compartment = compartment {
-      print(compartment.name)
+      logger.info("\(compartment.name)")
     }
     #expect(compartment != nil, "The compartment should not be nil")
   }
@@ -161,7 +161,7 @@ struct IAMTest {
 
     if let resources = bulkActionResourceTypes?.items {
       for resource in resources {
-        print(resource.name)
+        logger.info("\(resource.name)")
       }
     }
 
@@ -193,7 +193,7 @@ struct IAMTest {
     // Listing compartments
     if let compartments = listOfCompartments {
       for compartment in compartments {
-        print("Compartment: \(compartment.name)")
+        logger.info("Compartment: \(compartment.name)")
       }
     }
     #expect(listOfCompartments != nil, "Expected a non-nil list of compartments")
@@ -241,7 +241,7 @@ struct IAMTest {
     let recoverCompartment = try? await sut.recoverCompartment(compartmentId: testCompartment)
 
     if let compartment = recoverCompartment {
-      print("Compartment: \(compartment.name) was recovered from deleting.")
+      logger.info("Compartment: \(compartment.name) was recovered from deleting.")
     }
 
     #expect(recoverCompartment != nil, "The compartment should be recovered successfully.")
@@ -269,7 +269,7 @@ struct IAMTest {
 
     // Print the new name and description the updated compartment
     if let compartment = updatedCompartment {
-      print("Compartment: \(compartment.name) with description: \(compartment.description) was updated.")
+      logger.info("Compartment: \(compartment.name) with description: \(compartment.description) was updated.")
     }
     #expect(updatedCompartment != nil, "The compartment should be updated successfully.")
   }

--- a/Tests/Services/OCICaptureTests.swift
+++ b/Tests/Services/OCICaptureTests.swift
@@ -44,7 +44,7 @@ struct OCICaptureTests {
   @Test func captureGetNamespace() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let base = env["OCI_CAPTURE_BASE_URL"], let out = env["OCI_FIXTURE_OUT"] else {
-      print("OCICaptureTests skipped — set OCI_CAPTURE_BASE_URL and OCI_FIXTURE_OUT to record.")
+      logger.info("OCICaptureTests skipped — set OCI_CAPTURE_BASE_URL and OCI_FIXTURE_OUT to record.")
       return
     }
 
@@ -64,17 +64,17 @@ struct OCICaptureTests {
     )
 
     let namespace = try await client.getNamespace()
-    print("OCICaptureTests: captured getNamespace -> \"\(namespace)\"; fixture written under \(out)")
+    logger.info("OCICaptureTests: captured getNamespace -> \"\(namespace)\"; fixture written under \(out)")
   }
 
   // MARK: - Secrets Retrieval API captures
 
   /// Builds a live, recording `SecretsClient` for the configured profile, or
-  /// returns `nil` (with a printed reason) when the required env vars are absent
+  /// returns `nil` (with a logged reason) when the required env vars are absent
   /// so the capture self-skips in CI.
   private func makeRecordingSecretsClient(_ env: [String: String]) throws -> (client: SecretsClient, out: String)? {
     guard let out = env["OCI_FIXTURE_OUT"], let configFile = env["OCI_CONFIG_FILE"] else {
-      print("Secrets capture skipped — set OCI_FIXTURE_OUT and OCI_CONFIG_FILE to record.")
+      logger.info("Secrets capture skipped — set OCI_FIXTURE_OUT and OCI_CONFIG_FILE to record.")
       return nil
     }
     let profile = env["OCI_PROFILE"] ?? "DEFAULT"
@@ -91,37 +91,37 @@ struct OCICaptureTests {
   @Test func captureGetSecretBundle() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let secretId = env["OCI_SECRET_ID"] else {
-      print("captureGetSecretBundle skipped — set OCI_SECRET_ID.")
+      logger.info("captureGetSecretBundle skipped — set OCI_SECRET_ID.")
       return
     }
     guard let (client, out) = try makeRecordingSecretsClient(env) else { return }
 
     let bundle = try await client.getSecretBundle(secretId: secretId)
-    print("OCICaptureTests: captured getSecretBundle v\(bundle.versionNumber); fixture written under \(out)")
+    logger.info("OCICaptureTests: captured getSecretBundle v\(bundle.versionNumber); fixture written under \(out)")
   }
 
   @Test func captureListSecretBundleVersions() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let secretId = env["OCI_SECRET_ID"] else {
-      print("captureListSecretBundleVersions skipped — set OCI_SECRET_ID.")
+      logger.info("captureListSecretBundleVersions skipped — set OCI_SECRET_ID.")
       return
     }
     guard let (client, out) = try makeRecordingSecretsClient(env) else { return }
 
     let versions = try await client.listSecretBundleVersions(secretId: secretId)
-    print("OCICaptureTests: captured listSecretBundleVersions -> \(versions.count) versions; fixture written under \(out)")
+    logger.info("OCICaptureTests: captured listSecretBundleVersions -> \(versions.count) versions; fixture written under \(out)")
   }
 
   @Test func captureGetSecretBundleByName() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let secretName = env["OCI_SECRET_NAME"], let vaultId = env["OCI_VAULT_ID"] else {
-      print("captureGetSecretBundleByName skipped — set OCI_SECRET_NAME and OCI_VAULT_ID.")
+      logger.info("captureGetSecretBundleByName skipped — set OCI_SECRET_NAME and OCI_VAULT_ID.")
       return
     }
     guard let (client, out) = try makeRecordingSecretsClient(env) else { return }
 
     let bundle = try await client.getSecretBundleByName(secretName: secretName, vaultId: vaultId)
-    print("OCICaptureTests: captured getSecretBundleByName v\(bundle.versionNumber); fixture written under \(out)")
+    logger.info("OCICaptureTests: captured getSecretBundleByName v\(bundle.versionNumber); fixture written under \(out)")
   }
 
   /// Captures a real 404 error body/headers. The recording transport writes the
@@ -130,12 +130,12 @@ struct OCICaptureTests {
   @Test func captureGetSecretBundleNotFound() async throws {
     let env = ProcessInfo.processInfo.environment
     guard let badSecretId = env["OCI_BAD_SECRET_ID"] else {
-      print("captureGetSecretBundleNotFound skipped — set OCI_BAD_SECRET_ID.")
+      logger.info("captureGetSecretBundleNotFound skipped — set OCI_BAD_SECRET_ID.")
       return
     }
     guard let (client, out) = try makeRecordingSecretsClient(env) else { return }
 
     _ = try? await client.getSecretBundle(secretId: badSecretId)
-    print("OCICaptureTests: captured getSecretBundle 404 fixture under \(out)")
+    logger.info("OCICaptureTests: captured getSecretBundle 404 fixture under \(out)")
   }
 }

--- a/Tests/Services/ObjectStorageTest.swift
+++ b/Tests/Services/ObjectStorageTest.swift
@@ -86,7 +86,7 @@ struct ObjectStorageTest {
     )
 
     // Prints the name of the new bucket
-    print("Created bucket: \(bucket.name)")
+    logger.info("Created bucket: \(bucket.name)")
 
     #expect(bucket.name == "test_bucket_by_sdk", "Bucket name should match the requested one")
   }
@@ -115,7 +115,7 @@ struct ObjectStorageTest {
     )
 
     // Prints the name of the new bucket
-    print("Created bucket: \(bucket.name)")
+    logger.info("Created bucket: \(bucket.name)")
 
     #expect(bucket.name == "archive_test_bucket_by_sdk", "Bucket name should match the requested one")
   }
@@ -180,7 +180,7 @@ struct ObjectStorageTest {
 
     // Prints rule
     if let rule = createRetentionRule {
-      print("You applied rule: \(rule.displayName).")
+      logger.info("You applied rule: \(rule.displayName).")
     }
     #expect(createRetentionRule != nil, "The operation should succeed")
   }
@@ -214,7 +214,7 @@ struct ObjectStorageTest {
 
     if let createPreauthenticatedRequest {
       let host = Service.objectstorage.getHost(in: region)
-      print(host + createPreauthenticatedRequest.accessUri)
+      logger.info("\(host + createPreauthenticatedRequest.accessUri)")
     }
     #expect(createPreauthenticatedRequest != nil, "The operation should succeed")
   }
@@ -247,7 +247,7 @@ struct ObjectStorageTest {
 
     if let createPreauthenticatedRequest {
       let host = Service.objectstorage.getHost(in: region)
-      print(host + createPreauthenticatedRequest.accessUri)
+      logger.info("\(host + createPreauthenticatedRequest.accessUri)")
     }
     #expect(createPreauthenticatedRequest != nil, "The operation should succeed")
   }
@@ -403,9 +403,7 @@ struct ObjectStorageTest {
 
     // Prints the name of the bucket
     if let getBucket {
-      print(
-        "The bucket: \(getBucket.name) is in the compartment: \(getBucket.compartmentId), created by: \(getBucket.createdBy)"
-      )
+      logger.info("The bucket: \(getBucket.name) is in the compartment: \(getBucket.compartmentId), created by: \(getBucket.createdBy)")
     }
 
     #expect(getBucket != nil, "The return value should not be nil")
@@ -427,7 +425,7 @@ struct ObjectStorageTest {
     let namespace = try await sut.getNamespace()
 
     // Prints the namespace
-    print("The current namespace is: \(namespace)")
+    logger.info("The current namespace is: \(namespace)")
     #expect(!namespace.isEmpty, "Namespace should not be empty")
   }
 
@@ -476,9 +474,7 @@ struct ObjectStorageTest {
 
     // Prints metadata
     if let metadata = getNamespaceMetadata {
-      print(
-        "default-swift-compartment-id: \(metadata.defaultSwiftCompartmentId), \ndefault-s3-compartment-id: \(metadata.defaultS3CompartmentId), \nnamespace: \(metadata.namespace)"
-      )
+      logger.info("default-swift-compartment-id: \(metadata.defaultSwiftCompartmentId), \ndefault-s3-compartment-id: \(metadata.defaultS3CompartmentId), \nnamespace: \(metadata.namespace)")
     }
     #expect(getNamespaceMetadata != nil, "The operation should succeed")
   }
@@ -518,7 +514,7 @@ struct ObjectStorageTest {
       parURL: URL(string: "https://objectstorage.us-ashburn-1.oraclecloud.com/p/ugf-ZiRD-jayajvUvmJ1Uzva5ICb36kRaok7SNA1iOZU00Z1ujTPa6StuGfKSAcj/n/idhwcifwd5xy/b/myTestBucket/o/")!,
       objectName: "dir1/test_file.txt"
     )
-    print("downloaded object size: \(getObject?.count ?? -1)")
+    logger.info("downloaded object size: \(getObject?.count ?? -1)")
     #expect(getObject != nil, "The operation should succeed")
   }
 
@@ -561,7 +557,7 @@ struct ObjectStorageTest {
 
     // Print policy details
     if let policy = getReplicationPolicy {
-      print("id: \(policy.id) - name: \(policy.name)")
+      logger.info("id: \(policy.id) - name: \(policy.name)")
     }
     #expect(getReplicationPolicy != nil, "The operation should succeed")
   }
@@ -610,7 +606,7 @@ struct ObjectStorageTest {
     // Prints retention rule
     if let rule = getRetentionRule {
       if let timeCreated = rule.timeCreated {
-        print("id: \(rule.id) - name: \(rule.displayName) on \(timeCreated)")
+        logger.info("id: \(rule.id) - name: \(rule.displayName) on \(timeCreated)")
       }
     }
     #expect(getRetentionRule != nil, "The operation should succeed")
@@ -658,7 +654,7 @@ struct ObjectStorageTest {
 
     // Lists all buckets in the compartment
     for bucket in listOfBuckets {
-      print(bucket.name)
+      logger.info("\(bucket.name)")
     }
     #expect(
       listOfBuckets.count > 0,
@@ -688,7 +684,7 @@ struct ObjectStorageTest {
 
     // Lists all buckets in the compartment
     for bucket in listOfBuckets {
-      print(bucket.name)
+      logger.info("\(bucket.name)")
     }
     #expect(
       listOfBuckets.count < 3,
@@ -718,7 +714,7 @@ struct ObjectStorageTest {
     // Print polices
     if let policies = listReplicationPolicies {
       for policy in policies {
-        print("id: \(policy.id) - name: \(policy.name)")
+        logger.info("id: \(policy.id) - name: \(policy.name)")
       }
     }
     #expect(listReplicationPolicies != nil, "The operation should succeed")
@@ -747,7 +743,7 @@ struct ObjectStorageTest {
     // Print resources
     if let resources = listReplicationResources {
       for resource in resources {
-        print("id: \(resource.id) - name: \(resource.name) - destination: \(resource.destinationBucketName)")
+        logger.info("id: \(resource.id) - name: \(resource.name) - destination: \(resource.destinationBucketName)")
       }
     }
     #expect(listReplicationResources != nil, "The operation should succeed")
@@ -776,7 +772,7 @@ struct ObjectStorageTest {
 
       for rule in rules.items {
         if let timeCreated = rule.timeCreated {
-          print("- id: \(rule.id) name: \(rule.displayName) on \(timeCreated)")
+          logger.info("- id: \(rule.id) name: \(rule.displayName) on \(timeCreated)")
         }
       }
     }
@@ -806,7 +802,7 @@ struct ObjectStorageTest {
     if let objects = listOfObjects {
       for object in objects.objects {
         if let timeCreated = object.timeCreated, let size = object.size {
-          print("The name of the file: \(object.name), size: \(size) on \(timeCreated)")
+          logger.info("The name of the file: \(object.name), size: \(size) on \(timeCreated)")
         }
       }
     }
@@ -836,7 +832,7 @@ struct ObjectStorageTest {
     if let objectsInBucket = listOfObjects {
       for object in objectsInBucket.objects {
         if let size = object.size, let timeCreated = object.timeCreated, let md5 = object.md5, let storageTier = object.storageTier {
-          print("Name: \(object.name), size: \(size), created on: \(timeCreated), md5: \(md5), storageTier: \(storageTier)")
+          logger.info("Name: \(object.name), size: \(size), created on: \(timeCreated), md5: \(md5), storageTier: \(storageTier)")
         }
       }
     }
@@ -867,7 +863,7 @@ struct ObjectStorageTest {
     if let objectsInBucket = listOfObjects {
       for object in objectsInBucket.objects {
         if let size = object.size, let timeCreated = object.timeCreated, let timeModified = object.timeModified, let md5 = object.md5 {
-          print("Name: \(object.name), size: \(size), created on: \(timeCreated), modified: \(timeModified) and md5: \(md5)")
+          logger.info("Name: \(object.name), size: \(size), created on: \(timeCreated), modified: \(timeModified) and md5: \(md5)")
         }
       }
     }
@@ -896,7 +892,7 @@ struct ObjectStorageTest {
     if let objectsInBucket = listOfObjects {
       for object in objectsInBucket.objects {
         if let size = object.size, let timeCreated = object.timeCreated {
-          print("Name: \(object.name), size: \(size), created on: \(timeCreated)")
+          logger.info("Name: \(object.name), size: \(size), created on: \(timeCreated)")
         }
       }
     }
@@ -928,7 +924,7 @@ struct ObjectStorageTest {
     // Prints versions
     if let versions = listOfObjectVersions?.items {
       for version in versions {
-        print("File: \(version.name), size: \(version.size ?? 0), md5: \(version.md5 ?? "") and version: \(version.versionId)")
+        logger.info("File: \(version.name), size: \(version.size ?? 0), md5: \(version.md5 ?? "") and version: \(version.versionId)")
       }
     }
     #expect(listOfObjectVersions != nil, "The operation should succeed")
@@ -1213,12 +1209,12 @@ struct ObjectStorageTest {
     )
 
     if let updateBucket {
-      print(updateBucket.name)
+      logger.info("\(updateBucket.name)")
     }
 
     // Prints the new name of the updated bucket
     if let updateBucket {
-      print(updateBucket.name)
+      logger.info("\(updateBucket.name)")
     }
     #expect(updateBucket != nil, "The return value should not be nil")
   }
@@ -1244,12 +1240,12 @@ struct ObjectStorageTest {
     )
 
     if let updateBucket {
-      print(updateBucket.name)
+      logger.info("\(updateBucket.name)")
     }
 
     // Prints the new name of the updated bucket
     if let updateBucket {
-      print(updateBucket.name)
+      logger.info("\(updateBucket.name)")
     }
     #expect(updateBucket != nil, "The return value should not be nil")
   }
@@ -1278,9 +1274,7 @@ struct ObjectStorageTest {
 
     // Prints metadata
     if let updateNamespaceMetadata {
-      print(
-        "default-swift-compartment-id: \(updateNamespaceMetadata.defaultSwiftCompartmentId), \ndefault-s3-compartment-id: \(updateNamespaceMetadata.defaultS3CompartmentId), \nnamespace: \(updateNamespaceMetadata.namespace)"
-      )
+      logger.info("default-swift-compartment-id: \(updateNamespaceMetadata.defaultSwiftCompartmentId), \ndefault-s3-compartment-id: \(updateNamespaceMetadata.defaultS3CompartmentId), \nnamespace: \(updateNamespaceMetadata.namespace)")
     }
     #expect(updateNamespaceMetadata != nil, "The operation should succeed")
   }
@@ -1340,7 +1334,7 @@ struct ObjectStorageTest {
     // Prints updated retention rule
     if let rule = updateRetentionRule {
       if let timeRuleLocked = rule.timeRuleLocked {
-        print("New rule applies lock on \(timeRuleLocked)")
+        logger.info("New rule applies lock on \(timeRuleLocked)")
       }
     }
     #expect(updateRetentionRule != nil, "The operation should succeed")

--- a/Tests/Services/SecretsTest.swift
+++ b/Tests/Services/SecretsTest.swift
@@ -513,9 +513,9 @@ struct SecretsIntegrationTest {
 
     // Print secret info (not the actual content for security)
     if let bundle = secretBundle {
-      print("Secret ID: \(bundle.secretId)")
-      print("Version: \(bundle.versionNumber)")
-      print("Stages: \(bundle.stages ?? [])")
+      logger.info("Secret ID: \(bundle.secretId)")
+      logger.info("Version: \(bundle.versionNumber)")
+      logger.info("Stages: \(bundle.stages ?? [])")
     }
 
     #expect(secretBundle != nil, "Secret bundle should not be nil")
@@ -540,7 +540,7 @@ struct SecretsIntegrationTest {
     )
 
     if let bundle = secretBundle {
-      print("Retrieved version: \(bundle.versionNumber)")
+      logger.info("Retrieved version: \(bundle.versionNumber)")
       #expect(bundle.versionNumber == 1, "Should retrieve version 1")
     }
 
@@ -566,7 +566,7 @@ struct SecretsIntegrationTest {
     )
 
     if let bundle = secretBundle {
-      print("Stages: \(bundle.stages ?? [])")
+      logger.info("Stages: \(bundle.stages ?? [])")
       #expect(bundle.stages?.contains(.current) == true, "Should contain CURRENT stage")
     }
 
@@ -594,8 +594,8 @@ struct SecretsIntegrationTest {
     )
 
     if let bundle = secretBundle {
-      print("Secret ID: \(bundle.secretId)")
-      print("Version: \(bundle.versionNumber)")
+      logger.info("Secret ID: \(bundle.secretId)")
+      logger.info("Version: \(bundle.versionNumber)")
     }
 
     #expect(secretBundle != nil, "Secret bundle should not be nil")
@@ -619,9 +619,9 @@ struct SecretsIntegrationTest {
     let versions = try? await sut.listSecretBundleVersions(secretId: testSecretId)
 
     if let versions {
-      print("Found \(versions.count) version(s)")
+      logger.info("Found \(versions.count) version(s)")
       for version in versions {
-        print("  Version \(version.versionNumber): \(version.stages ?? [])")
+        logger.info("  Version \(version.versionNumber): \(version.stages ?? [])")
       }
     }
 
@@ -647,7 +647,7 @@ struct SecretsIntegrationTest {
     )
 
     if let versions {
-      print("Found \(versions.count) version(s) (limit 5)")
+      logger.info("Found \(versions.count) version(s) (limit 5)")
       #expect(versions.count <= 5, "Should return at most 5 versions")
     }
 
@@ -711,7 +711,7 @@ struct SecretsIntegrationTest {
       #expect(decodedData != nil, "Should be able to decode Base64 content")
 
       // Don't print actual secret value for security
-      print("Secret content length: \(decodedData?.count ?? 0) bytes")
+      logger.info("Secret content length: \(decodedData?.count ?? 0) bytes")
     }
 
     #expect(secretBundle != nil, "Secret bundle should not be nil")


### PR DESCRIPTION
## What

Route **test** diagnostics through the shared swift-log `logger` instead of `print`, so output is level-controlled and consistent with the SDK. Stacked on top of #76.

## How

The SDK already exposes a public global `logger` (`Logger(label: "OCIKit")` in `core/Signer.swift`) — `ObjectStorageTest` already used it. It's in scope wherever `OCIKit` is imported, so this change needs **no new imports or logger declarations**: every `print(...)` in the test suites becomes `logger.info(...)`.

- All 85 `print(...)` calls across the test suites → `logger.info(...)`.
- Bare-expression arguments are wrapped: `print(bucket.name)` → `logger.info("\(bucket.name)")`.
- Dropped one stray, **production** `print` in `GenerateText.swift` — the line directly above already logs the same response body at `.debug`.

## Scope

Test-only, plus that one redundant library `print`. No behavior change to the SDK's request/response paths.

## Verification

- `swift build --build-tests` — clean on **macOS**.
- `swift build --build-tests` in `swift:6.2` Docker — clean on **Linux arm64** (all three test targets compile).
