### PR TITLE
Implement retry support: honor retryConfig in all service clients

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ env:
   # Regex (OR-separated) of swift-testing suite type names that are pure unit
   # tests — no ~/.oci/config, no network, no env vars. These MUST pass in CI.
   UNIT_TEST_FILTER: >-
-    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests|ResourcePrincipalSourceTests|ResourcePrincipalTokenTests|ResourcePrincipalEnvironmentTests|ResourcePrincipalSigningTests|ContainerInstancesRouterTests|ContainerInstancesEnumsTests|ContainerInstancesModelEncodingTests|ContainerInstancesModelDecodingTests|ObjectStorageHermeticTests|OCIFixtureReplayTests|SecretsHermeticTests
+    SecretBundleDecodingTests|SecretBundleContentDetailsDecodingTests|SecretBundleVersionSummaryDecodingTests|SecretsEnumsTests|SecretsRouterTests|SecretsErrorTests|ResourcePrincipalSourceTests|ResourcePrincipalTokenTests|ResourcePrincipalEnvironmentTests|ResourcePrincipalSigningTests|ContainerInstancesRouterTests|ContainerInstancesEnumsTests|ContainerInstancesModelEncodingTests|ContainerInstancesModelDecodingTests|ObjectStorageHermeticTests|OCIFixtureReplayTests|SecretsHermeticTests|RetryConfigTests|HTTPClientRetryTests|ObjectStorageRetryTests
 
 jobs:
   build-and-test:

--- a/Sources/OCIKit/core/HTTPClient+Retry.swift
+++ b/Sources/OCIKit/core/HTTPClient+Retry.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+//
+// The shared execution path for all service clients: sign → send, with optional
+// retries. The loop wraps *both* steps so every attempt is signed afresh — a
+// replayed signature can fall outside OCI's ±5 minute clock-skew window after a
+// long backoff, and instance/resource principal tokens can rotate between
+// attempts. See https://github.com/iliasaz/oci-swift-sdk/issues/78.
+//
+
+import Foundation
+import Logging
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension HTTPClient {
+  /// Signs and performs `request`, retrying failed attempts per `retry`.
+  ///
+  /// Each attempt starts from the pristine, unsigned `request` and signs it anew,
+  /// so `date` headers stay fresh and token-based signers can rotate credentials
+  /// mid-sequence. A `401` from a ``RefreshableSigner`` triggers one immediate
+  /// force-refresh-and-retry outside the retry budget, so requests ride through
+  /// a token rotation that lands exactly at request time.
+  ///
+  /// When the retry budget is exhausted, the most recent response is returned
+  /// (or the most recent transport error rethrown) — status-code handling stays
+  /// with the calling operation, which maps it to its service-specific error.
+  ///
+  /// - Parameters:
+  ///   - request: The unsigned request to perform.
+  ///   - signer: The signer applied to every attempt, or `nil` for requests that
+  ///     need no signature (e.g. pre-authenticated-request URLs).
+  ///   - retry: The retry configuration; `nil` performs a single attempt.
+  ///   - logger: Logger used to record retry decisions at debug level.
+  public func send(
+    _ request: URLRequest,
+    signer: Signer?,
+    retry: RetryConfig?,
+    logger: Logger
+  ) async throws -> (Data, URLResponse) {
+    var attempt = 1
+    var cumulativeDelay: TimeInterval = 0
+    var refreshedAfter401 = false
+
+    while true {
+      var req = request
+      if let signer {
+        try signer.sign(&req)
+      }
+
+      let data: Data
+      let response: URLResponse
+      do {
+        (data, response) = try await self.data(req)
+      }
+      catch {
+        guard let retry, retry.isTransient(error), attempt < retry.maxAttempts else {
+          throw error
+        }
+        let delay = retry.delay(forAttempt: attempt)
+        guard cumulativeDelay + delay <= retry.maxCumulativeDelay else {
+          throw error
+        }
+        logger.debug("Transient error on attempt \(attempt)/\(retry.maxAttempts), retrying in \(delay)s: \(error)")
+        try await Task.sleep(for: .seconds(delay))
+        cumulativeDelay += delay
+        attempt += 1
+        continue
+      }
+
+      guard let http = response as? HTTPURLResponse else {
+        return (data, response)
+      }
+
+      // Auth failure with a refreshable signer: force a token refresh and retry
+      // once immediately, outside the normal retry budget.
+      if http.statusCode == 401, !refreshedAfter401, let refreshable = signer as? RefreshableSigner {
+        refreshedAfter401 = true
+        logger.debug("Received 401 on attempt \(attempt); forcing signer refresh and retrying once")
+        try refreshable.forceRefresh()
+        continue
+      }
+
+      guard let retry, retry.retryableStatusCodes.contains(http.statusCode), attempt < retry.maxAttempts else {
+        return (data, response)
+      }
+      let retryAfter = http.value(forHTTPHeaderField: "Retry-After").flatMap(RetryConfig.retryAfterSeconds(from:))
+      let delay = retry.delay(forAttempt: attempt, retryAfter: retryAfter)
+      guard cumulativeDelay + delay <= retry.maxCumulativeDelay else {
+        return (data, response)
+      }
+      logger.debug("HTTP \(http.statusCode) on attempt \(attempt)/\(retry.maxAttempts), retrying in \(delay)s")
+      try await Task.sleep(for: .seconds(delay))
+      cumulativeDelay += delay
+      attempt += 1
+    }
+  }
+}

--- a/Sources/OCIKit/core/InstancePrincipalSigner.swift
+++ b/Sources/OCIKit/core/InstancePrincipalSigner.swift
@@ -18,7 +18,7 @@ import _CryptoExtras
 
 // MARK: - InstancePrincipalSigner
 
-public struct InstancePrincipalSigner: Signer {
+public struct InstancePrincipalSigner: RefreshableSigner {
   private let delegate: X509FederationClientBasedSecurityTokenSigner
 
   public init(
@@ -36,6 +36,12 @@ public struct InstancePrincipalSigner: Signer {
 
   public func sign(_ req: inout URLRequest) throws {
     try delegate.sign(&req)
+  }
+
+  /// Invalidates the cached security token so the next ``sign(_:)`` re-federates
+  /// with the instance identity certificates. Called after a `401`.
+  public func forceRefresh() throws {
+    try delegate.forceRefresh()
   }
 }
 
@@ -160,6 +166,11 @@ final class InstancePrincipalsFederationClient: X509FederationClientProtocol, @u
 
   func currentPrivateKey() throws -> _RSA.Signing.PrivateKey {
     return sessionPrivateKey
+  }
+
+  /// Drops the cached token so the next `currentSecurityToken()` re-federates.
+  func forceRefresh() throws {
+    token = nil
   }
 
   // MARK: - Token refresh

--- a/Sources/OCIKit/core/ResourcePrincipalSigner.swift
+++ b/Sources/OCIKit/core/ResourcePrincipalSigner.swift
@@ -130,7 +130,7 @@ enum ResourcePrincipalSource: Equatable {
 /// let signer = try ResourcePrincipalSigner.fromEnvironment()
 /// let client = try ObjectStorageClient(region: .fra, signer: signer)
 /// ```
-public final class ResourcePrincipalSigner: Signer, @unchecked Sendable {
+public final class ResourcePrincipalSigner: RefreshableSigner, @unchecked Sendable {
   private let rpstSource: ResourcePrincipalSource
   private let keySource: ResourcePrincipalSource
 
@@ -228,7 +228,8 @@ public final class ResourcePrincipalSigner: Signer, @unchecked Sendable {
           return (token, key)
         }
         // Token is within the jitter window — fall through and refresh.
-      } else {
+      }
+      else {
         // No exp claim to evaluate; keep the cached material.
         return (token, key)
       }

--- a/Sources/OCIKit/core/RetryConfig.swift
+++ b/Sources/OCIKit/core/RetryConfig.swift
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// Configuration for automatic retries of failed service requests.
+///
+/// Retries use exponential backoff with full jitter: before attempt `n + 1` the
+/// client sleeps for a random duration in `0...min(maxDelay, baseDelay * exponentialGrowthFactor^(n-1))`.
+/// When the response carries a parseable `Retry-After` header, that value is
+/// honored instead of the computed backoff.
+///
+/// A request is retried when the response status code is in ``retryableStatusCodes``,
+/// or when the transport throws a transient connection error (see
+/// ``retriesOnConnectionErrors``). Every attempt is signed afresh, so `date`
+/// headers stay within OCI's clock-skew window and token-based signers can
+/// rotate credentials between attempts.
+///
+/// The defaults mirror the Python SDK's `DEFAULT_RETRY_STRATEGY`: 8 total
+/// attempts, 1 s base delay, 30 s per-sleep cap, and a 600 s cumulative sleep
+/// budget. Passing `nil` for a client's `retryConfig` disables retries entirely
+/// (the historical behavior, and the Python SDK's default).
+public struct RetryConfig: Sendable {
+  /// Total number of attempts, including the initial one. Must be at least 1.
+  public var maxAttempts: Int
+  /// Base delay in seconds used for the exponential backoff calculation.
+  public var baseDelay: TimeInterval
+  /// Upper bound in seconds for any single backoff sleep.
+  public var maxDelay: TimeInterval
+  /// Growth factor applied per attempt in the exponential backoff calculation.
+  public var exponentialGrowthFactor: Double
+  /// Upper bound in seconds for the total time spent sleeping between attempts.
+  /// Once the budget is exhausted, the most recent outcome is returned or rethrown.
+  public var maxCumulativeDelay: TimeInterval
+  /// HTTP status codes that trigger a retry.
+  public var retryableStatusCodes: Set<Int>
+  /// Whether transient connection errors (timeouts, dropped connections, DNS
+  /// failures) thrown by the transport also trigger a retry.
+  public var retriesOnConnectionErrors: Bool
+
+  /// A ready-to-use configuration mirroring the Python SDK's default strategy.
+  public static let `default` = RetryConfig()
+
+  public init(
+    maxAttempts: Int = 8,
+    baseDelay: TimeInterval = 1,
+    maxDelay: TimeInterval = 30,
+    exponentialGrowthFactor: Double = 2,
+    maxCumulativeDelay: TimeInterval = 600,
+    retryableStatusCodes: Set<Int> = [429, 500, 502, 503, 504],
+    retriesOnConnectionErrors: Bool = true
+  ) {
+    self.maxAttempts = max(1, maxAttempts)
+    self.baseDelay = baseDelay
+    self.maxDelay = maxDelay
+    self.exponentialGrowthFactor = exponentialGrowthFactor
+    self.maxCumulativeDelay = maxCumulativeDelay
+    self.retryableStatusCodes = retryableStatusCodes
+    self.retriesOnConnectionErrors = retriesOnConnectionErrors
+  }
+
+  /// Returns the number of seconds to sleep before the attempt following `attempt`
+  /// (1-based). A server-provided `Retry-After` value is honored verbatim;
+  /// otherwise full jitter is applied over the capped exponential backoff.
+  func delay(forAttempt attempt: Int, retryAfter: TimeInterval? = nil) -> TimeInterval {
+    if let retryAfter, retryAfter >= 0 {
+      return retryAfter
+    }
+    let exponential = baseDelay * pow(exponentialGrowthFactor, Double(max(0, attempt - 1)))
+    let cap = min(maxDelay, exponential)
+    guard cap > 0 else { return 0 }
+    return Double.random(in: 0...cap)
+  }
+
+  /// Parses a `Retry-After` header value in its delta-seconds form (the form OCI
+  /// uses). Returns `nil` for HTTP-date or otherwise unparseable values, in which
+  /// case the computed backoff applies.
+  static func retryAfterSeconds(from value: String) -> TimeInterval? {
+    guard let seconds = TimeInterval(value.trimmingCharacters(in: .whitespaces)), seconds >= 0 else {
+      return nil
+    }
+    return seconds
+  }
+
+  /// Whether `error` is a transient connection failure worth retrying, mirroring
+  /// the Python SDK's timeout/connection-error checkers.
+  func isTransient(_ error: Error) -> Bool {
+    guard retriesOnConnectionErrors, let urlError = error as? URLError else { return false }
+    switch urlError.code {
+    case .timedOut, .cannotConnectToHost, .networkConnectionLost, .dnsLookupFailed,
+      .cannotFindHost, .notConnectedToInternet, .secureConnectionFailed:
+      return true
+    default:
+      return false
+    }
+  }
+}

--- a/Sources/OCIKit/core/Signer.swift
+++ b/Sources/OCIKit/core/Signer.swift
@@ -35,9 +35,30 @@ public protocol Signer: Sendable {
   func sign(_ req: inout URLRequest) throws
 }
 
+/// A signer whose credentials can be forcibly refreshed after an authentication
+/// failure.
+///
+/// Token-based signers cache short-lived security tokens that can be rejected by
+/// the service (HTTP `401`) even though they still look valid locally — e.g. when
+/// the underlying instance identity certificate rotates. When a request signed by
+/// a `RefreshableSigner` receives a `401`, ``HTTPClient/send(_:signer:retry:logger:)``
+/// calls ``forceRefresh()`` and retries the request once.
+public protocol RefreshableSigner: Signer {
+  /// Discards any cached security material so the next ``Signer/sign(_:)`` call
+  /// obtains fresh credentials.
+  func forceRefresh() throws
+}
+
 public protocol X509FederationClientProtocol: Sendable {
   func currentSecurityToken() throws -> String
   func currentPrivateKey() throws -> _RSA.Signing.PrivateKey
+  /// Invalidates any cached security token so the next ``currentSecurityToken()``
+  /// re-federates. The default implementation does nothing.
+  func forceRefresh() throws
+}
+
+extension X509FederationClientProtocol {
+  public func forceRefresh() throws {}
 }
 
 enum RequestSigner {

--- a/Sources/OCIKit/core/X509FederationClientBasedSecurityTokenSigner.swift
+++ b/Sources/OCIKit/core/X509FederationClientBasedSecurityTokenSigner.swift
@@ -11,7 +11,7 @@ import Foundation
   import FoundationNetworking
 #endif
 
-public final class X509FederationClientBasedSecurityTokenSigner: Signer, @unchecked Sendable {
+public final class X509FederationClientBasedSecurityTokenSigner: RefreshableSigner, @unchecked Sendable {
   private let federationClient: X509FederationClientProtocol
 
   public init(federationClient: X509FederationClientProtocol) {
@@ -23,5 +23,11 @@ public final class X509FederationClientBasedSecurityTokenSigner: Signer, @unchec
     let key = try federationClient.currentPrivateKey()
     let delegateSigner = SecurityTokenSigner(securityToken: token, privateKey: key)
     try delegateSigner.sign(&req)
+  }
+
+  /// Invalidates the federation client's cached token so the next ``sign(_:)``
+  /// re-federates. Called after a `401` to ride through token rotation.
+  public func forceRefresh() throws {
+    try federationClient.forceRefresh()
   }
 }

--- a/Sources/OCIKit/services/ContainerInstances/ContainerInstances.swift
+++ b/Sources/OCIKit/services/ContainerInstances/ContainerInstances.swift
@@ -51,6 +51,7 @@ public struct ContainerInstancesClient: Sendable {
   let retryConfig: RetryConfig?
   let signer: Signer
   let logger: Logger
+  let httpClient: HTTPClient
 
   // MARK: - Initialization
 
@@ -60,8 +61,10 @@ public struct ContainerInstancesClient: Sendable {
   ///   - region: A region used to determine the service endpoint.
   ///   - endpoint: A fully-qualified endpoint URL. Takes precedence over `region`.
   ///   - signer: A signer used to authenticate requests.
-  ///   - retryConfig: Optional retry configuration.
+  ///   - retryConfig: The retry configuration applied to every operation of this client. `nil` (the default) disables retries.
   ///   - logger: Optional logger.
+  ///   - httpClient: The HTTP transport used to perform requests. Defaults to ``HTTPClient/live``
+  ///     (real `URLSession` I/O); tests can inject a recording or replaying transport.
   /// - Throws: ``ContainerInstancesError/missingRequiredParameter(_:)`` if neither
   ///   `region` nor `endpoint` is provided.
   public init(
@@ -69,11 +72,13 @@ public struct ContainerInstancesClient: Sendable {
     endpoint: String? = nil,
     signer: Signer,
     retryConfig: RetryConfig? = nil,
-    logger: Logger = Logger(label: "ContainerInstancesClient")
+    logger: Logger = Logger(label: "ContainerInstancesClient"),
+    httpClient: HTTPClient = .live
   ) throws {
     self.signer = signer
     self.retryConfig = retryConfig
     self.logger = logger
+    self.httpClient = httpClient
 
     if let endpoint, let endpointURL = URL(string: endpoint) {
       self.endpoint = endpointURL
@@ -134,9 +139,16 @@ public struct ContainerInstancesClient: Sendable {
   ) async throws -> ContainerInstanceCollection {
     let (data, _) = try await execute(
       .listContainerInstances(
-        compartmentId: compartmentId, lifecycleState: lifecycleState, displayName: displayName,
-        availabilityDomain: availabilityDomain, limit: limit, page: page, sortOrder: sortOrder,
-        sortBy: sortBy, opcRequestId: opcRequestId),
+        compartmentId: compartmentId,
+        lifecycleState: lifecycleState,
+        displayName: displayName,
+        availabilityDomain: availabilityDomain,
+        limit: limit,
+        page: page,
+        sortOrder: sortOrder,
+        sortBy: sortBy,
+        opcRequestId: opcRequestId
+      ),
       expectedStatus: 200
     )
     return try decode(ContainerInstanceCollection.self, from: data, op: "listContainerInstances")
@@ -245,8 +257,12 @@ public struct ContainerInstancesClient: Sendable {
   ) async throws -> ContainerInstanceShapeCollection {
     let (data, _) = try await execute(
       .listContainerInstanceShapes(
-        compartmentId: compartmentId, availabilityDomain: availabilityDomain, limit: limit, page: page,
-        opcRequestId: opcRequestId),
+        compartmentId: compartmentId,
+        availabilityDomain: availabilityDomain,
+        limit: limit,
+        page: page,
+        opcRequestId: opcRequestId
+      ),
       expectedStatus: 200
     )
     return try decode(ContainerInstanceShapeCollection.self, from: data, op: "listContainerInstanceShapes")
@@ -278,9 +294,17 @@ public struct ContainerInstancesClient: Sendable {
   ) async throws -> ContainerCollection {
     let (data, _) = try await execute(
       .listContainers(
-        compartmentId: compartmentId, lifecycleState: lifecycleState, displayName: displayName,
-        containerInstanceId: containerInstanceId, availabilityDomain: availabilityDomain, limit: limit,
-        page: page, sortOrder: sortOrder, sortBy: sortBy, opcRequestId: opcRequestId),
+        compartmentId: compartmentId,
+        lifecycleState: lifecycleState,
+        displayName: displayName,
+        containerInstanceId: containerInstanceId,
+        availabilityDomain: availabilityDomain,
+        limit: limit,
+        page: page,
+        sortOrder: sortOrder,
+        sortBy: sortBy,
+        opcRequestId: opcRequestId
+      ),
       expectedStatus: 200
     )
     return try decode(ContainerCollection.self, from: data, op: "listContainers")
@@ -360,9 +384,17 @@ public struct ContainerInstancesClient: Sendable {
   ) async throws -> ContainerInstanceWorkRequestSummaryCollection {
     let (data, _) = try await execute(
       .listWorkRequests(
-        compartmentId: compartmentId, workRequestId: workRequestId, resourceId: resourceId,
-        availabilityDomain: availabilityDomain, status: status, limit: limit, page: page,
-        sortOrder: sortOrder, sortBy: sortBy, opcRequestId: opcRequestId),
+        compartmentId: compartmentId,
+        workRequestId: workRequestId,
+        resourceId: resourceId,
+        availabilityDomain: availabilityDomain,
+        status: status,
+        limit: limit,
+        page: page,
+        sortOrder: sortOrder,
+        sortBy: sortBy,
+        opcRequestId: opcRequestId
+      ),
       expectedStatus: 200
     )
     return try decode(ContainerInstanceWorkRequestSummaryCollection.self, from: data, op: "listWorkRequests")
@@ -379,8 +411,13 @@ public struct ContainerInstancesClient: Sendable {
   ) async throws -> ContainerInstanceWorkRequestErrorCollection {
     let (data, _) = try await execute(
       .listWorkRequestErrors(
-        workRequestId: workRequestId, limit: limit, page: page, sortOrder: sortOrder, sortBy: sortBy,
-        opcRequestId: opcRequestId),
+        workRequestId: workRequestId,
+        limit: limit,
+        page: page,
+        sortOrder: sortOrder,
+        sortBy: sortBy,
+        opcRequestId: opcRequestId
+      ),
       expectedStatus: 200
     )
     return try decode(ContainerInstanceWorkRequestErrorCollection.self, from: data, op: "listWorkRequestErrors")
@@ -397,8 +434,13 @@ public struct ContainerInstancesClient: Sendable {
   ) async throws -> ContainerInstanceWorkRequestLogEntryCollection {
     let (data, _) = try await execute(
       .listWorkRequestLogs(
-        workRequestId: workRequestId, limit: limit, page: page, sortOrder: sortOrder, sortBy: sortBy,
-        opcRequestId: opcRequestId),
+        workRequestId: workRequestId,
+        limit: limit,
+        page: page,
+        sortOrder: sortOrder,
+        sortBy: sortBy,
+        opcRequestId: opcRequestId
+      ),
       expectedStatus: 200
     )
     return try decode(ContainerInstanceWorkRequestLogEntryCollection.self, from: data, op: "listWorkRequestLogs")
@@ -417,9 +459,8 @@ public struct ContainerInstancesClient: Sendable {
     }
     var req = try buildRequest(api: api, endpoint: endpoint)
     if let body { req.httpBody = body }
-    try signer.sign(&req)
 
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
     guard let http = response as? HTTPURLResponse else {
       throw ContainerInstancesError.invalidResponse("Invalid HTTP response")
     }

--- a/Sources/OCIKit/services/Identity and Access Management/IAM.swift
+++ b/Sources/OCIKit/services/Identity and Access Management/IAM.swift
@@ -25,17 +25,22 @@ public struct IAMClient: Sendable {
   let retryConfig: RetryConfig?
   let signer: Signer
   let logger: Logger
+  let httpClient: HTTPClient
 
   // MARK: - Initialization
-  /// Initialize the object storage client
+  /// Initialize the IAM client
   /// Parameters:
   ///     - region: A region used to determine the service endpoint.
   ///     - endpoint: The fully qualified endpoint URL
   ///     - signer: A signer implementation which can be used by this client.
-  public init(region: Region? = nil, endpoint: String? = nil, signer: Signer, retryConfig: RetryConfig? = nil, logger: Logger = Logger(label: "IAMClient")) throws {
+  ///     - retryConfig: The retry configuration applied to every operation of this client. `nil` (the default) disables retries.
+  ///     - httpClient: The HTTP transport used to perform requests. Defaults to ``HTTPClient/live``
+  ///       (real `URLSession` I/O); tests can inject a recording or replaying transport.
+  public init(region: Region? = nil, endpoint: String? = nil, signer: Signer, retryConfig: RetryConfig? = nil, logger: Logger = Logger(label: "IAMClient"), httpClient: HTTPClient = .live) throws {
     self.signer = signer
     self.retryConfig = retryConfig
     self.logger = logger
+    self.httpClient = httpClient
 
     if let endpoint, let endpointURL = URL(string: endpoint) {
       self.endpoint = endpointURL
@@ -92,9 +97,7 @@ public struct IAMClient: Sendable {
     }
 
     req.httpBody = payload
-    try signer.sign(&req)
-
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")
@@ -157,9 +160,7 @@ public struct IAMClient: Sendable {
     }
 
     req.httpBody = payload
-    try signer.sign(&req)
-
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")
@@ -220,9 +221,7 @@ public struct IAMClient: Sendable {
     }
 
     req.httpBody = payload
-    try signer.sign(&req)
-
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")
@@ -256,11 +255,9 @@ public struct IAMClient: Sendable {
       throw IAMError.missingRequiredParameter("No endpoint has been set")
     }
     let api = IAMAPI.deleteCompartment(compartmentId: compartmentId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")
@@ -304,11 +301,9 @@ public struct IAMClient: Sendable {
       throw IAMError.missingRequiredParameter("No endpoint has been set")
     }
     let api = IAMAPI.getCompartment(compartmentId: compartmentId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")
@@ -364,10 +359,9 @@ public struct IAMClient: Sendable {
     }
     let api = IAMAPI.listBulkActionResourceTypes(bulkActionTytpe: bulkActionType.rawValue, page: page, limit: limit)
 
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")
@@ -435,10 +429,9 @@ public struct IAMClient: Sendable {
       sortOrder: sortOrder,
       lifecycleState: lifecycleState
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")
@@ -506,9 +499,7 @@ public struct IAMClient: Sendable {
     }
 
     req.httpBody = payload
-    try signer.sign(&req)
-
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")
@@ -549,10 +540,9 @@ public struct IAMClient: Sendable {
       throw IAMError.missingRequiredParameter("No endpoint has been set")
     }
     let api = IAMAPI.recoverCompartment(compartmentId: compartmentId, opcRequestId: opcRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")
@@ -607,9 +597,7 @@ public struct IAMClient: Sendable {
     }
 
     req.httpBody = payload
-    try signer.sign(&req)
-
-    let (data, response) = try await URLSession.shared.data(for: req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw IAMError.invalidResponse("Invalid HTTP response")

--- a/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
+++ b/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
@@ -33,13 +33,15 @@ public struct ObjectStorageClient: Sendable {
   ///     - region: A region used to determine the service endpoint.
   ///     - endpoint: The fully qualified endpoint URL
   ///     - signer: A signer implementation which can be used by this client.
+  ///     - retryConfig: The retry configuration applied to every operation of this client. `nil` (the default) disables retries; individual operations can override it via their own `retryConfig` parameter.
   ///
   ///  TODO:
   ///     - proxySettings: If your environment requires you to use a proxy server for outgoing HTTP requests the details for the proxy can be provided in this parameter
-  ///     - retryConfig: The retry configuration for this service client
   ///
   ///     Either a region or an endpoint must be specified. If an endpoint is specified, it will be used instead of the region.
-  public init(region: Region? = nil, endpoint: String? = nil, signer: Signer, retryConfig: RetryConfig? = nil, logger: Logger = Logger(label: "ObjectStorageClient"), httpClient: HTTPClient = .live) throws {
+  public init(region: Region? = nil, endpoint: String? = nil, signer: Signer, retryConfig: RetryConfig? = nil, logger: Logger = Logger(label: "ObjectStorageClient"), httpClient: HTTPClient = .live)
+    throws
+  {
     self.signer = signer
     self.retryConfig = retryConfig
     self.logger = logger
@@ -65,20 +67,20 @@ public struct ObjectStorageClient: Sendable {
   /// - Parameters:
   ///   - workRequestId: The ID of the asynchronous request.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   public func cancelWorkRequest(
     workRequestId: String,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.cancelWorkRequest(workRequestId: workRequestId, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -108,9 +110,9 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - copyObjectDetails: The source and destination of the object to be copied.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// TODO:
-  ///   - retryConfig: The retry configuration to apply to this operation. If no value is provided, the service-level retry configuration will be used. If `nil` is explicitly provided, the operation will not retry.
   ///   - opcSseCustomerAlgorithm: Optional header specifying `"AES256"` as the encryption algorithm. [More info](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
   ///   - opcSseCustomerKey: Optional header specifying the base64-encoded 256-bit encryption key to encrypt or decrypt the data. [More info](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
   ///   - opcSseCustomerKeySha256: Optional header specifying the base64-encoded SHA256 hash of the encryption key to verify its integrity. [More info](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
@@ -118,7 +120,7 @@ public struct ObjectStorageClient: Sendable {
   ///   - opcSourceSseCustomerKey: Optional header specifying the base64-encoded 256-bit encryption key to decrypt the source object. [More info](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
   ///   - opcSourceSseCustomerKeySha256: Optional header specifying the base64-encoded SHA256 hash of the encryption key used to decrypt the source object. [More info](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
   ///   - opcSseKmsKeyId: The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of a master encryption key used to call the Key Management service.
-  public func copyObject(namespaceName: String, bucketName: String, copyObjectDetails: CopyObjectDetails, opcClientRequestId: String? = nil) async throws {
+  public func copyObject(namespaceName: String, bucketName: String, copyObjectDetails: CopyObjectDetails, opcClientRequestId: String? = nil, retryConfig: RetryConfig? = nil) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
@@ -137,9 +139,7 @@ public struct ObjectStorageClient: Sendable {
 
       req.httpBody = payload
 
-      try signer.sign(&req)
-
-      let (data, response) = try await httpClient.data(req)
+      let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -151,7 +151,9 @@ public struct ObjectStorageClient: Sendable {
         throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
       }
 
-      if let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"), let opcWorkRequestId = httpResponse.value(forHTTPHeaderField: "opc-work-request-id"), let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id") {
+      if let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"), let opcWorkRequestId = httpResponse.value(forHTTPHeaderField: "opc-work-request-id"),
+        let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id")
+      {
         logger.debug("opc-request-id: \(opcRequestId), opc-work-request-id: \(opcWorkRequestId), opc-client-request-id: \(opcClientRequestId)")
       }
     }
@@ -167,8 +169,9 @@ public struct ObjectStorageClient: Sendable {
   /// - Parameters:
   ///     - namespaceName: The Object Storage namespace used for the request.
   ///     - opcClientRequestId: Optional client request ID for tracing.
+  ///     - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///  - Returns: The response body will contain a single Bucket resource.
-  public func createBucket(namespaceName: String, createBucketDetails: CreateBucketDetails, opcClientRequestId: String? = nil) async throws -> Bucket {
+  public func createBucket(namespaceName: String, createBucketDetails: CreateBucketDetails, opcClientRequestId: String? = nil, retryConfig: RetryConfig? = nil) async throws -> Bucket {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
@@ -187,9 +190,7 @@ public struct ObjectStorageClient: Sendable {
 
       req.httpBody = payload
 
-      try signer.sign(&req)
-
-      let (data, response) = try await httpClient.data(req)
+      let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -222,16 +223,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - policyDetails: The replication policy details to be created.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing `ReplicationPolicy`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation. If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func createReplicationPolicy(
     namespaceName: String,
     bucketName: String,
     policyDetails: CreateReplicationPolicyDetails,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> ReplicationPolicy {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -254,9 +254,7 @@ public struct ObjectStorageClient: Sendable {
     }
 
     req.httpBody = payload
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -282,16 +280,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - ruleDetails: The retention rule to create for the bucket.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing `RetentionRule`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation. If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func createRetentionRule(
     namespaceName: String,
     bucketName: String,
     ruleDetails: CreateRetentionRuleDetails,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> RetentionRule {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -314,9 +311,7 @@ public struct ObjectStorageClient: Sendable {
     }
 
     req.httpBody = payload
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -340,13 +335,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - requestDetails: Information needed to create the pre-authenticated request.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing `PreauthenticatedRequest`.
   public func createPreauthenticatedRequest(
     namespaceName: String,
     bucketName: String,
     requestDetails: CreatePreauthenticatedRequestDetails,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> PreauthenticatedRequest {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -369,9 +366,7 @@ public struct ObjectStorageClient: Sendable {
     }
 
     req.httpBody = payload
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -396,27 +391,23 @@ public struct ObjectStorageClient: Sendable {
   ///   - namespaceName: The Object Storage namespace used for the request.
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object with data of type `Void`.
   ///
   /// TODO:
-  /// - retryConfig: The retry configuration to apply to this operation. If no value is provided,
-  /// the service-level retry configuration will be used. If `nil` is explicitly provided,
-  /// the operation will not retry.
   ///  - ifMatch: The entity tag (ETag) to match with the ETag of an existing resource.
   ///  If the specified ETag matches, GET and HEAD requests will return the resource,
   ///  and PUT and POST requests will upload the resource.
-  public func deleteBucket(namespaceName: String, bucketName: String, opcClientRequestId: String? = nil) async throws {
+  public func deleteBucket(namespaceName: String, bucketName: String, opcClientRequestId: String? = nil, retryConfig: RetryConfig? = nil) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.deleteBucket(namespaceName: namespaceName, bucketName: bucketName, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -442,29 +433,28 @@ public struct ObjectStorageClient: Sendable {
   ///   - objectName: The name of the object to delete. Avoid entering confidential information. Example: `"test/object1.log"`
   ///   - opcClientRequestId: Optional client request ID for tracing.
   ///   - versionId: Optional version ID used to identify a particular version of the object.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object with no data payload (`Void`).
   ///
   /// TODO:
-  ///   - retryConfig: The retry configuration to apply to this operation. If no value is provided, the service-level retry configuration will be used. If `nil` is explicitly provided, the operation will not retry.
   ///   - ifMatch: The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches, GET and HEAD requests will return the resource, and PUT and POST requests will upload the resource.
   public func deleteObject(
     namespaceName: String,
     bucketName: String,
     objectName: String,
     opcClientRequestId: String? = nil,
-    versionId: String? = nil
+    versionId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.deleteObject(namespaceName: namespaceName, bucketName: bucketName, objectName: objectName, opcClientRequestId: opcClientRequestId, versionId: versionId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -476,7 +466,8 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
     }
 
-    if let isDeleteMarker = httpResponse.value(forHTTPHeaderField: "is-delete-marker"), let lastModified = httpResponse.value(forHTTPHeaderField: "last-modified"), let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"),
+    if let isDeleteMarker = httpResponse.value(forHTTPHeaderField: "is-delete-marker"), let lastModified = httpResponse.value(forHTTPHeaderField: "last-modified"),
+      let opcClientRequestId = httpResponse.value(forHTTPHeaderField: "opc-client-request-id"),
       let opcRequestId = httpResponse.value(forHTTPHeaderField: "opc-request-id"), let versionId = httpResponse.value(forHTTPHeaderField: "version-id")
     {
       logger.debug("is-delete-marker: \(isDeleteMarker), last-modified: \(lastModified), opc-client-request-id: \(opcClientRequestId), opc-request-id: \(opcRequestId), version-id: \(versionId)")
@@ -491,16 +482,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - replicationId: The ID of the replication policy to delete.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object with no data (void).
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation. If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func deleteReplicationPolicy(
     namespaceName: String,
     bucketName: String,
     replicationId: String,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -512,11 +502,9 @@ public struct ObjectStorageClient: Sendable {
       replicationId: replicationId,
       opcClientRequestId: opcClientRequestId
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -544,17 +532,18 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - retentionRuleId: The ID of the retention rule to delete.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object with no data (void).
   ///
   /// TODO:
   ///   - ifMatch: Optional ETag value for optimistic concurrency control.
-  ///   - retryConfig: Optional retry configuration for this operation.
   public func deleteRetentionRule(
     namespaceName: String,
     bucketName: String,
     retentionRuleId: String,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -566,11 +555,9 @@ public struct ObjectStorageClient: Sendable {
       retentionId: retentionRuleId,
       opcClientRequestId: opcClientRequestId
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -597,16 +584,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - parId: The unique identifier for the pre-authenticated request.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object with no data (void).
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation.
   public func deletePreauthenticatedRequest(
     namespaceName: String,
     bucketName: String,
     parId: String,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -618,11 +604,9 @@ public struct ObjectStorageClient: Sendable {
       parId: parId,
       opcClientRequestId: opcClientRequestId
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -648,12 +632,10 @@ public struct ObjectStorageClient: Sendable {
   ///     - namespaceName: The Object Storage namespace used for the request.
   ///     - bucketName: The name of the bucket. Avoid entering confidential information.
   ///     - opcClientRequestId: Optional client request ID for tracing.
+  ///     - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   /// - Returns: A bucket representation for the requested bucket.
   ///
   /// TODO:
-  ///     - retryConfig: Optional The retry configuration to apply to this operation. If no key is provided,
-  ///     then the service-level retry configuration defined by `retryConfig` will be used.
-  ///     If an explicit `nil` value is provided, the operation will not retry.
   ///   - ifMatch: Optional The entity tag (ETag) to match with the ETag of an existing resource.
   ///     If the specified ETag matches the ETag of the existing resource, `GET` and `HEAD` requests
   ///     will return the resource, and `PUT` and `POST` requests will upload the resource.
@@ -666,17 +648,15 @@ public struct ObjectStorageClient: Sendable {
   ///     - `approximateSize`: Total approximate size in bytes of all objects in the bucket.
   ///     - `autoTiering`: State of auto tiering on the bucket.
   ///
-  public func getBucket(namespaceName: String, bucketName: String, opcClientRequestId: String? = nil) async throws -> Bucket {
+  public func getBucket(namespaceName: String, bucketName: String, opcClientRequestId: String? = nil, retryConfig: RetryConfig? = nil) async throws -> Bucket {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.getBucket(namespaceName: namespaceName, bucketName: bucketName, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -709,20 +689,18 @@ public struct ObjectStorageClient: Sendable {
   /// - Parameters:
   ///   - compartmentId: his is an optional field representing either the tenancy [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) or the compartment [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) within the tenancy whose Object Storage namespace is to be retrieved.
   ///   - opcClientRequestId: Optional client request ID for tracing.
-  ///   - retryConfig: Optional retry configuration to apply to this operation. If `nil`, the default service-level retry configuration is used. If explicitly set to `nil`, the operation will not retry.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `String` containing the Object Storage namespace.
-  public func getNamespace(compartmentId: String? = nil) async throws -> String {
+  public func getNamespace(compartmentId: String? = nil, retryConfig: RetryConfig? = nil) async throws -> String {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.getNamespace()
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -752,22 +730,18 @@ public struct ObjectStorageClient: Sendable {
   /// - Parameters:
   ///   - namespaceName: The Object Storage namespace used for the request.
   ///   - opcClientRequestId: The client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object containing `NamespaceMetadata`.
-  ///
-  /// TODO:
-  ///   - retryConfig: The retry configuration to apply to this operation. If no value is provided, the service-level retry configuration will be used. If `nil` is explicitly provided, the operation will not retry.
-  public func getNamespaceMetadata(namespaceName: String, opcClientRequestId: String? = nil) async throws -> NamespaceMetadata {
+  public func getNamespaceMetadata(namespaceName: String, opcClientRequestId: String? = nil, retryConfig: RetryConfig? = nil) async throws -> NamespaceMetadata {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.getNamespaceMetadata(namespaceName: namespaceName, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -803,6 +777,7 @@ public struct ObjectStorageClient: Sendable {
   ///   - httpResponseContentLanguage: Query parameter to override the `Content-Language` response header.
   ///   - httpResponseContentEncoding: Query parameter to override the `Content-Encoding` response header.
   ///   - httpResponseExpires: Query parameter to override the `Expires` response header.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Data` object containing the raw contents of the object.
   public func getObject(
@@ -821,7 +796,8 @@ public struct ObjectStorageClient: Sendable {
     httpResponseContentLanguage: String? = nil,
     httpResponseContentEncoding: String? = nil,
     httpResponseExpires: String? = nil,
-    withObjectIntegrityCheck: Bool = false
+    withObjectIntegrityCheck: Bool = false,
+    retryConfig: RetryConfig? = nil
   ) async throws -> Data {
 
     let api = ObjectStorageAPI.getObject(
@@ -845,11 +821,9 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -896,6 +870,7 @@ public struct ObjectStorageClient: Sendable {
   ///   - httpResponseExpires: Query parameter to override the `Expires` response header.
   ///   - withObjectIntegrityCheck: If `true`, validates the object length and MD5 checksum against
   ///     values reported by Object Storage.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Data` object containing the raw contents of the object.
   public func getObject(
@@ -913,7 +888,8 @@ public struct ObjectStorageClient: Sendable {
     httpResponseContentLanguage: String? = nil,
     httpResponseContentEncoding: String? = nil,
     httpResponseExpires: String? = nil,
-    withObjectIntegrityCheck: Bool = false
+    withObjectIntegrityCheck: Bool = false,
+    retryConfig: RetryConfig? = nil
   ) async throws -> Data {
 
     // The endpoint here is different from the above implementation because it already contains /p, /n, and /b in it.
@@ -940,7 +916,7 @@ public struct ObjectStorageClient: Sendable {
 
     let req = try buildRequest(api: api, endpoint: baseURL)
 
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: nil, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -986,16 +962,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - replicationId: The ID of the replication policy to retrieve.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing `ReplicationPolicy`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation. If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func getReplicationPolicy(
     namespaceName: String,
     bucketName: String,
     replicationId: String,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> ReplicationPolicy {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -1007,11 +982,9 @@ public struct ObjectStorageClient: Sendable {
       replicationId: replicationId,
       opcClientRequestId: opcClientRequestId
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1035,17 +1008,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - retentionRuleId: The ID of the retention rule to retrieve.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing `RetentionRule`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation.
-  ///     If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func getRetentionRule(
     namespaceName: String,
     bucketName: String,
     retentionRuleId: String,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> RetentionRule {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -1057,11 +1028,9 @@ public struct ObjectStorageClient: Sendable {
       retentionId: retentionRuleId,
       opcClientRequestId: opcClientRequestId
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1085,17 +1054,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - parId: The unique identifier for the pre-authenticated request.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing `PreauthenticatedRequestSummary`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation.
-  ///     If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func getPreauthenticatedRequest(
     namespaceName: String,
     bucketName: String,
     parId: String,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> PreauthenticatedRequestSummary {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -1107,11 +1074,9 @@ public struct ObjectStorageClient: Sendable {
       parId: parId,
       opcClientRequestId: opcClientRequestId
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1133,22 +1098,22 @@ public struct ObjectStorageClient: Sendable {
   /// - Parameters:
   ///   - workRequestId: The ID of the asynchronous request.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `WorkRequest` object containing the status of the work request.
   public func getWorkRequestStatus(
     workRequestId: String,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> WorkRequest {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.getWorkRequest(workRequestId: workRequestId, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1171,29 +1136,26 @@ public struct ObjectStorageClient: Sendable {
   ///   - namespaceName: The Object Storage namespace used for the request.
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object with no data payload (`Void`).
   ///
   /// TODO:
-  ///  - retryConfig: The retry configuration to apply to this operation. If no value is provided,
-  ///  the service-level retry configuration will be used. If `nil` is explicitly provided, the operation will not retry.
   ///  - ifMatch: The entity tag (ETag) to match with the ETag of an existing resource.
   ///  If the specified ETag matches, GET and HEAD requests will return the resource,
   ///  and PUT and POST requests will upload the resource.
   ///  - ifNoneMatch: The entity tag (ETag) to avoid matching. Wildcards (`*`) are not allowed.
   ///  If the specified ETag does not match the existing resource, the request returns the expected response.
   ///  If it matches, the request returns HTTP 304 without a response body.
-  public func headBucket(namespaceName: String, bucketName: String, opcClientRequestId: String? = nil) async throws {
+  public func headBucket(namespaceName: String, bucketName: String, opcClientRequestId: String? = nil, retryConfig: RetryConfig? = nil) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.headBucket(namespaceName: namespaceName, bucketName: bucketName, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1222,11 +1184,11 @@ public struct ObjectStorageClient: Sendable {
   ///   - opcSseCustomerAlgorithm: Optional header specifying `"AES256"` as the encryption algorithm. [More info](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
   ///   - opcSseCustomerKey: Optional header specifying the base64-encoded 256-bit encryption key to encrypt or decrypt the data. [More info](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
   ///   - opcSseCustomerKeySha256: Optional header specifying the base64-encoded SHA256 hash of the encryption key to verify its integrity. [More info](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object with no data payload (`Void`).
   ///
   /// TODO:
-  ///   - retryConfig: The retry configuration to apply to this operation. If no value is provided, the service-level retry configuration will be used. If `nil` is explicitly provided, the operation will not retry.
   ///   - ifMatch: The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches, GET and HEAD requests will return the resource, and PUT and POST requests will upload the resource.
   ///   - ifNoneMatch: The entity tag (ETag) to avoid matching. Wildcards (`*`) are not allowed. If the specified ETag does not match, the request returns the expected response. If it matches, the request returns HTTP 304 without a response body.
   public func headObject(
@@ -1237,7 +1199,8 @@ public struct ObjectStorageClient: Sendable {
     opcClientRequestId: String? = nil,
     opcSseCustomerAlgorithm: String? = nil,
     opcSseCustomerKey: String? = nil,
-    opcSseCustomerKeySha256: String? = nil
+    opcSseCustomerKeySha256: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -1253,11 +1216,9 @@ public struct ObjectStorageClient: Sendable {
       opcSseCustomerKey: opcSseCustomerKey,
       opcSseCustomerKeySha256: opcSseCustomerKeySha256
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1341,8 +1302,17 @@ public struct ObjectStorageClient: Sendable {
   ///     - page: Optional value of the opc-next-page response header from the previous "List" call.
   ///     - fields:  The only supported value of this parameter is 'tags' for now.
   ///     - opcClientRequestId: Optional client request ID for tracing.
+  ///     - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///  - Returns: The response body will contain an array of BucketSummary resources.
-  public func listBuckets(namespaceName: String, compartmentId: String, limit: Int? = nil, page: String? = nil, fields: [String] = ["tags"], opcClientRequestId: String? = nil) async throws
+  public func listBuckets(
+    namespaceName: String,
+    compartmentId: String,
+    limit: Int? = nil,
+    page: String? = nil,
+    fields: [String] = ["tags"],
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
+  ) async throws
     -> [BucketSummary]
   {
     guard let endpoint else {
@@ -1350,11 +1320,9 @@ public struct ObjectStorageClient: Sendable {
     }
 
     let api = ObjectStorageAPI.listBuckets(namespaceName: namespaceName, compartmentId: compartmentId, limit: limit, page: page, fields: fields, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1380,28 +1348,25 @@ public struct ObjectStorageClient: Sendable {
   ///   - page: Optional pagination token from the previous response's `opc-next-page` header.
   ///   - limit: Optional maximum number of results per page. Defaults to 100.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing an array of `ReplicationPolicySummary`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation. If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func listReplicationPolicies(
     namespaceName: String,
     bucketName: String,
     page: String? = nil,
     limit: Int? = 100,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> [ReplicationPolicySummary] {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.listReplicationPolicies(namespaceName: namespaceName, bucketName: bucketName, page: page, limit: limit, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1426,28 +1391,25 @@ public struct ObjectStorageClient: Sendable {
   ///   - page: Optional pagination token from the previous response's `opc-next-page` header.
   ///   - limit: Optional maximum number of results per page. Defaults to 100.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing an array of `ReplicationSource`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation. If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func listReplicationSources(
     namespaceName: String,
     bucketName: String,
     page: String? = nil,
     limit: Int? = 100,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> [ReplicationSource] {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.listReplicationSources(namespaceName: namespaceName, bucketName: bucketName, page: page, limit: limit, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1471,29 +1433,25 @@ public struct ObjectStorageClient: Sendable {
   ///   - namespaceName: The Object Storage namespace used for the request.
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - page: Optional pagination token from the previous response's `opc-next-page` header.
-
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing `RetentionRuleCollection`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation. If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func listRetentionRules(
     namespaceName: String,
     bucketName: String,
     page: String? = nil,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> RetentionRuleCollection {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.listRetentionRules(namespaceName: namespaceName, bucketName: bucketName, page: page, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1535,6 +1493,7 @@ public struct ObjectStorageClient: Sendable {
   ///     Valid values: `name`, `size`, `etag`, `md5`, `timeCreated`, `timeModified`, `storageTier`, `archivalState`.
   ///   - opcClientRequestId: Optional client request ID for tracing.
   ///   - startAfter: Optional returns object names lexicographically strictly greater than this value.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object containing `ListObjects`.
   public func listObjects(
@@ -1547,7 +1506,8 @@ public struct ObjectStorageClient: Sendable {
     delimiter: String? = nil,
     fields: [Field] = [],
     opcClientRequestId: String? = nil,
-    startAfter: String? = nil
+    startAfter: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> ListObjects {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -1566,11 +1526,9 @@ public struct ObjectStorageClient: Sendable {
       opcClientRequiredId: opcClientRequestId,
       startAfter: startAfter
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1612,6 +1570,7 @@ public struct ObjectStorageClient: Sendable {
   ///     Valid values: `name`, `size`, `etag`, `md5`, `timeCreated`, `timeModified`, `storageTier`, `archivalState`.
   ///   - opcClientRequestId: Optional client request ID for tracing.
   ///   - startAfter: Optional returns object names lexicographically strictly greater than this value.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object containing `ListObjects`.
 
@@ -1624,7 +1583,8 @@ public struct ObjectStorageClient: Sendable {
     delimiter: String? = nil,
     fields: [Field] = [],
     opcClientRequestId: String? = nil,
-    startAfter: String? = nil
+    startAfter: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> ListObjects {
 
     let customFields = Array(Set(fields + [.name, .size, .timeCreated, .timeModified]))
@@ -1646,7 +1606,7 @@ public struct ObjectStorageClient: Sendable {
     }
     let req = try buildRequest(api: api, endpoint: baseURL)
 
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: nil, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1684,11 +1644,9 @@ public struct ObjectStorageClient: Sendable {
   ///   - opcClientRequestId: Optional client request ID for tracing. Optional.
   ///   - startAfter: Returns object names lexicographically strictly greater than this value.
   ///   - page: Optional pagination, use the value from the previous response's `opc-next-page` header.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object containing `ObjectVersionCollection`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Retry configuration for the operation.
   public func listObjectVersions(
     namespaceName: String,
     bucketName: String,
@@ -1701,6 +1659,7 @@ public struct ObjectStorageClient: Sendable {
     opcClientRequestId: String? = nil,
     startAfter: String? = nil,
     page: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> ObjectVersionCollection {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -1719,11 +1678,9 @@ public struct ObjectStorageClient: Sendable {
       startAfter: startAfter,
       page: page
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1749,18 +1706,17 @@ public struct ObjectStorageClient: Sendable {
   ///   - limit: Optional maximum number of results per page for pagination.
   ///   - page: Optional pagination token from a previous response's `opc-next-page` header.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing an array of `PreauthenticatedRequestSummary`.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation. If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func listPreauthenticatedRequests(
     namespaceName: String,
     bucketName: String,
     objectNamePrefix: String? = nil,
     limit: Int? = nil,
     page: String? = nil,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> [PreauthenticatedRequestSummary] {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -1774,11 +1730,9 @@ public struct ObjectStorageClient: Sendable {
       page: page,
       opcClientRequestId: opcClientRequestId
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1803,6 +1757,7 @@ public struct ObjectStorageClient: Sendable {
   ///   - opcClientRequestId: Optional client request ID for tracing.
   ///   - page: Optional pagination token from a previous list response (`opc-next-page`).
   ///   - limit: Optional maximum number of results to return per page.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `[WorkRequestSummary]` containing the list of work requests.
   public func listWorkRequests(
@@ -1810,17 +1765,16 @@ public struct ObjectStorageClient: Sendable {
     opcClientRequestId: String? = nil,
     page: String? = nil,
     limit: Int? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> [WorkRequestSummary] {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.listWorkRequests(compartmentId: compartmentId, opcCLientRequestId: opcClientRequestId, page: page, limit: limit)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1845,15 +1799,14 @@ public struct ObjectStorageClient: Sendable {
   ///   - namespaceName: The Object Storage namespace used for the request.
   ///   - bucketName: The name of the destination bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object with no data (void).
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for this operation. If not provided, the service-level retry config will be used. If `nil`, no retry will occur.
   public func makeBucketWritable(
     namespaceName: String,
     bucketName: String,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -1864,11 +1817,9 @@ public struct ObjectStorageClient: Sendable {
       bucketName: bucketName,
       opcClientRequestId: opcClientRequestId
     )
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1902,6 +1853,7 @@ public struct ObjectStorageClient: Sendable {
   ///  - contentMD5: Optional header that defines the base64-encoded MD5 hash of the body.
   ///   - opcClientRequestId: Optional client request ID for tracing.
   ///   - storageTier: Optional storage tier for the object (e.g., Standard, Archive).
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   public func putObject(
     namespaceName: String,
     bucketName: String,
@@ -1912,6 +1864,7 @@ public struct ObjectStorageClient: Sendable {
     contentMD5: String? = nil,
     opcClientRequestId: String? = nil,
     storageTier: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -1938,10 +1891,8 @@ public struct ObjectStorageClient: Sendable {
 
     req.httpBody = putObjectBody
 
-    try signer.sign(&req)
-
     self.logger.info("[putObject] Starting upload of \(objectName) to folder: \(toFolder ?? "/")")
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -1991,6 +1942,7 @@ public struct ObjectStorageClient: Sendable {
   ///  - contentMD5: Optional header that defines the base64-encoded MD5 hash of the body.
   ///   - opcClientRequestId: Optional client request ID for tracing.
   ///   - storageTier: Optional storage tier for the object (e.g., Standard, Archive).
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   public func putObject(
     parURL: URL,
     objectName: String,
@@ -2000,6 +1952,7 @@ public struct ObjectStorageClient: Sendable {
     contentMD5: String? = nil,
     opcClientRequestId: String? = nil,
     storageTier: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     // The endpoint here is different from the above implementation because it already contains /p, /n, and /b in it.
     guard let host = parURL.host(), let baseURL = URL(string: "https://\(host)") else {
@@ -2029,7 +1982,7 @@ public struct ObjectStorageClient: Sendable {
 
     self.logger.info("[putObjectPAR] Starting upload of \(objectName) to folder: \(toFolder ?? "/")")
 
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: nil, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2084,22 +2037,18 @@ public struct ObjectStorageClient: Sendable {
   ///   - namespaceName: The Object Storage namespace used for the request.
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object with no data payload (`Void`).
-  ///
-  /// TODO:
-  ///- retryConfig: The retry configuration to apply to this operation. If no value is provided, the service-level retry configuration will be used. If `nil` is explicitly provided, the operation will not retry.
-  public func reencryptBucket(namespaceName: String, bucketName: String, opcClientRequestId: String? = nil) async throws {
+  public func reencryptBucket(namespaceName: String, bucketName: String, opcClientRequestId: String? = nil, retryConfig: RetryConfig? = nil) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
 
     let api = ObjectStorageAPI.reencryptBucket(namespaceName: namespaceName, bucketName: bucketName, opcClientRequestId: opcClientRequestId)
-    var req = try buildRequest(api: api, endpoint: endpoint)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    try signer.sign(&req)
-
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2131,18 +2080,17 @@ public struct ObjectStorageClient: Sendable {
   ///   - reencryptObjectDetails: Request object containing re-encryption configuration.
   ///   - versionId: Version ID used to identify a specific version of the object. Optional.
   ///   - opcClientRequestId: Client request ID for tracing. Optional.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object with no data payload (`Void`).
-  ///
-  /// TODO:
-  ///   - retryConfig: Retry configuration for the operation. Optional.
   public func reencryptObject(
     namespaceName: String,
     bucketName: String,
     objectName: String,
     reencryptObjectDetails: ReencryptObjectDetails,
     versionId: String? = nil,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -2162,9 +2110,7 @@ public struct ObjectStorageClient: Sendable {
 
       req.httpBody = payload
 
-      try signer.sign(&req)
-
-      let (data, response) = try await httpClient.data(req)
+      let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2193,16 +2139,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - renameObjectDetails: The source and destination object names for the rename operation. Avoid entering confidential information.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object with no data payload.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for the operation. If not provided, the service-level retry configuration will be used. If `nil`, the operation will not retry.
   public func renameObject(
     namespaceName: String,
     bucketName: String,
     renameObjectDetails: RenameObjectDetails,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -2222,9 +2167,7 @@ public struct ObjectStorageClient: Sendable {
 
       req.httpBody = payload
 
-      try signer.sign(&req)
-
-      let (data, response) = try await httpClient.data(req)
+      let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2265,12 +2208,10 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - restoreObjectsDetails: The request payload containing the object name and restore duration.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object with no data payload.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for the operation. If not provided, the service-level retry configuration will be used. If `nil`, the operation will not retry.
-  public func restoreObject(namespaceName: String, bucketName: String, restoreObjectsDetails: RestoreObjectsDetails, opcClientRequestId: String? = nil) async throws {
+  public func restoreObject(namespaceName: String, bucketName: String, restoreObjectsDetails: RestoreObjectsDetails, opcClientRequestId: String? = nil, retryConfig: RetryConfig? = nil) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
     }
@@ -2289,9 +2230,7 @@ public struct ObjectStorageClient: Sendable {
 
       req.httpBody = payload
 
-      try signer.sign(&req)
-
-      let (data, response) = try await httpClient.data(req)
+      let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2326,17 +2265,18 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - updateBucketDetails: The request object containing metadata updates for the bucket.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object containing the updated `Bucket`.
   ///
   /// TODO:
   ///  - ifMatch: The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches, GET and HEAD requests will return the resource, and PUT and POST requests will upload the resource.
-  ///  - retryConfig: The retry configuration to apply to this operation. If no value is provided, the service-level retry configuration will be used. If `nil` is explicitly provided, the operation will not retry.
   public func updateBucket(
     namespaceName: String,
     bucketName: String,
     updateBucketDetails: UpdateBucketDetails,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> Bucket {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -2356,9 +2296,7 @@ public struct ObjectStorageClient: Sendable {
 
       req.httpBody = payload
 
-      try signer.sign(&req)
-
-      let (data, response) = try await httpClient.data(req)
+      let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2396,16 +2334,14 @@ public struct ObjectStorageClient: Sendable {
   ///   - namespaceName: The Object Storage namespace used for the request.
   ///   - updateNamespaceMetadataDetails: The request object containing the new default compartment settings.
   ///   - opcClientRequestId: The client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A `Response` object containing `NamespaceMetadata`.
-  ///
-  /// TODO:
-  ///
-  ///   - retryConfig: The retry configuration to apply to this operation. If no value is provided, the service-level retry configuration will be used. If `nil` is explicitly provided, the operation will not retry.
   public func updateNamespaceMetadata(
     namespaceName: String,
     metadata: UpdateNamespaceMetadataDetails,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> NamespaceMetadata {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -2425,9 +2361,7 @@ public struct ObjectStorageClient: Sendable {
 
       req.httpBody = payload
 
-      try signer.sign(&req)
-
-      let (data, response) = try await httpClient.data(req)
+      let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2474,16 +2408,15 @@ public struct ObjectStorageClient: Sendable {
   ///   - bucketName: The name of the bucket. Avoid entering confidential information. Example: `"my-new-bucket1"`
   ///   - updateObjectStorageTierDetails: The object name and the desired storage tier.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object with no data payload.
-  ///
-  /// TODO:
-  ///   - retryConfig: Optional retry configuration for the operation. If not provided, the service-level retry configuration will be used. If `nil`, the operation will not retry.
   public func updateObjectStorageTier(
     namespaceName: String,
     bucketName: String,
     updateObjectStorageTierDetails: UpdateObjectStorageTierDetails,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -2503,9 +2436,7 @@ public struct ObjectStorageClient: Sendable {
 
       req.httpBody = payload
 
-      try signer.sign(&req)
-
-      let (data, response) = try await httpClient.data(req)
+      let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2537,18 +2468,19 @@ public struct ObjectStorageClient: Sendable {
   ///   - retentionRuleId: The ID of the retention rule.
   ///   - updateRetentionRuleDetails: Request object for updating the retention rule.
   ///   - opcClientRequestId: Optional client request ID for tracing.
+  ///   - retryConfig: The retry configuration to apply to this operation. If `nil` (the default), the client-level `retryConfig` is used. Pass `RetryConfig(maxAttempts: 1)` to disable retries for this call.
   ///
   /// - Returns: A response object containing the updated `RetentionRule`.
   ///
   /// TODO:
-  ///   - retryConfig: (Optional) The retry configuration to apply to this operation. If not provided, the service-level retry configuration will be used. If `nil`, the operation will not retry.
   ///   - ifMatch: (Optional) The entity tag (ETag) to match with the ETag of an existing resource. If matched, GET and HEAD requests will return the resource, and PUT and POST requests will upload the resource.
   public func updateRetentionRule(
     namespaceName: String,
     bucketName: String,
     retentionRuleId: String,
     updateRetentionRuleDetails: UpdateRetentionRuleDetails,
-    opcClientRequestId: String? = nil
+    opcClientRequestId: String? = nil,
+    retryConfig: RetryConfig? = nil
   ) async throws -> RetentionRule {
     guard let endpoint else {
       throw ObjectStorageError.missingRequiredParameter("No endpoint has been set")
@@ -2568,9 +2500,7 @@ public struct ObjectStorageClient: Sendable {
 
       req.httpBody = payload
 
-      try signer.sign(&req)
-
-      let (data, response) = try await httpClient.data(req)
+      let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig ?? self.retryConfig, logger: logger)
 
       guard let httpResponse = response as? HTTPURLResponse else {
         throw ObjectStorageError.invalidResponse("Invalid HTTP response")
@@ -2586,11 +2516,4 @@ public struct ObjectStorageClient: Sendable {
       return retenetiobRule
     }
   }
-}
-
-// TODO: Find proper place for these below
-// Retry configuration
-public struct RetryConfig: Sendable {
-  let maxAttempts: Int
-  let baseDelay: TimeInterval
 }

--- a/Sources/OCIKit/services/Secrets/Secrets.swift
+++ b/Sources/OCIKit/services/Secrets/Secrets.swift
@@ -52,7 +52,7 @@ public struct SecretsClient: Sendable {
   ///   - region: A region used to determine the service endpoint.
   ///   - endpoint: The fully qualified endpoint URL. If provided, this takes precedence over the region.
   ///   - signer: A signer implementation used for authenticating requests.
-  ///   - retryConfig: Optional retry configuration for this service client.
+  ///   - retryConfig: The retry configuration applied to every operation of this client. `nil` (the default) disables retries.
   ///   - logger: Optional logger for debugging and diagnostics.
   ///   - httpClient: The HTTP transport used to perform requests. Defaults to ``HTTPClient/live``
   ///     (real `URLSession` I/O); tests can inject a recording or replaying transport.
@@ -126,10 +126,9 @@ public struct SecretsClient: Sendable {
       opcRequestId: opcRequestId
     )
 
-    var req = try buildRequest(api: api, endpoint: endpoint)
-    try signer.sign(&req)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw SecretsError.invalidResponse("Invalid HTTP response")
@@ -192,10 +191,9 @@ public struct SecretsClient: Sendable {
       opcRequestId: opcRequestId
     )
 
-    var req = try buildRequest(api: api, endpoint: endpoint)
-    try signer.sign(&req)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw SecretsError.invalidResponse("Invalid HTTP response")
@@ -252,10 +250,9 @@ public struct SecretsClient: Sendable {
       opcRequestId: opcRequestId
     )
 
-    var req = try buildRequest(api: api, endpoint: endpoint)
-    try signer.sign(&req)
+    let req = try buildRequest(api: api, endpoint: endpoint)
 
-    let (data, response) = try await httpClient.data(req)
+    let (data, response) = try await httpClient.send(req, signer: signer, retry: retryConfig, logger: logger)
 
     guard let httpResponse = response as? HTTPURLResponse else {
       throw SecretsError.invalidResponse("Invalid HTTP response")

--- a/Tests/OCIKit/RetryTests.swift
+++ b/Tests/OCIKit/RetryTests.swift
@@ -1,0 +1,332 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+//
+// Hermetic tests for retry support (issue #78) — no credentials, no network.
+// A scripted transport returns a canned sequence of responses/errors, one per
+// attempt, so attempt counts, per-attempt re-signing, 401 refresh semantics,
+// and Retry-After handling are all asserted deterministically.
+//
+
+import Foundation
+import Testing
+
+@testable import OCIKit
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// MARK: - Test doubles
+
+/// One scripted transport outcome per attempt.
+private enum ScriptStep {
+  case response(status: Int, headers: [String: String], body: Data)
+  case failure(any Error)
+
+  static func status(_ code: Int) -> ScriptStep { .response(status: code, headers: [:], body: Data()) }
+}
+
+/// Pops one scripted step per request and records every request it saw.
+private actor ScriptedTransport {
+  private var steps: [ScriptStep]
+  private(set) var requests: [URLRequest] = []
+
+  init(_ steps: [ScriptStep]) { self.steps = steps }
+
+  var attemptCount: Int { requests.count }
+
+  func next(for request: URLRequest) throws -> (Data, URLResponse) {
+    requests.append(request)
+    guard !steps.isEmpty else {
+      // A test bug (more attempts than scripted) must fail fast, not loop.
+      throw URLError(.unsupportedURL)
+    }
+    switch steps.removeFirst() {
+    case .response(let status, let headers, let body):
+      let response = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headers)!
+      return (body, response)
+    case .failure(let error):
+      throw error
+    }
+  }
+}
+
+extension HTTPClient {
+  fileprivate static func scripted(_ transport: ScriptedTransport) -> HTTPClient {
+    HTTPClient { request in try await transport.next(for: request) }
+  }
+}
+
+/// Stamps an incrementing attempt number so tests can prove every attempt was re-signed.
+private final class CountingSigner: Signer, @unchecked Sendable {
+  private let lock = NSLock()
+  private var count = 0
+
+  func sign(_ req: inout URLRequest) throws {
+    lock.lock()
+    defer { lock.unlock() }
+    count += 1
+    req.setValue("attempt-\(count)", forHTTPHeaderField: "X-Test-Attempt")
+  }
+
+  var signCount: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return count
+  }
+}
+
+/// A refreshable signer that counts forceRefresh() calls.
+private final class RefreshCountingSigner: RefreshableSigner, @unchecked Sendable {
+  private let lock = NSLock()
+  private var refreshes = 0
+
+  func sign(_ req: inout URLRequest) throws {
+    req.setValue(#"Signature version="1""#, forHTTPHeaderField: "Authorization")
+  }
+
+  func forceRefresh() throws {
+    lock.lock()
+    defer { lock.unlock() }
+    refreshes += 1
+  }
+
+  var refreshCount: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return refreshes
+  }
+}
+
+private struct PlainSigner: Signer {
+  func sign(_ req: inout URLRequest) throws {
+    req.setValue(#"Signature version="1""#, forHTTPHeaderField: "Authorization")
+  }
+}
+
+/// Millisecond-scale delays keep the suite fast while exercising the real sleep path.
+private let fastRetry = RetryConfig(maxAttempts: 3, baseDelay: 0.001, maxDelay: 0.005)
+
+private func makeRequest() -> URLRequest {
+  URLRequest(url: URL(string: "https://objectstorage.us-ashburn-1.oraclecloud.com/n")!)
+}
+
+// MARK: - RetryConfig unit tests
+
+struct RetryConfigTests {
+
+  @Test("default configuration mirrors the Python SDK's default strategy")
+  func defaults() {
+    let config = RetryConfig.default
+    #expect(config.maxAttempts == 8)
+    #expect(config.baseDelay == 1)
+    #expect(config.maxDelay == 30)
+    #expect(config.exponentialGrowthFactor == 2)
+    #expect(config.maxCumulativeDelay == 600)
+    #expect(config.retryableStatusCodes == [429, 500, 502, 503, 504])
+    #expect(config.retriesOnConnectionErrors)
+  }
+
+  @Test("maxAttempts is clamped to at least one attempt")
+  func maxAttemptsClamped() {
+    #expect(RetryConfig(maxAttempts: 0).maxAttempts == 1)
+    #expect(RetryConfig(maxAttempts: -5).maxAttempts == 1)
+  }
+
+  @Test("delay applies full jitter within the capped exponential bound")
+  func delayBounds() {
+    let config = RetryConfig(baseDelay: 1, maxDelay: 30, exponentialGrowthFactor: 2)
+    for _ in 0..<100 {
+      #expect((0...1).contains(config.delay(forAttempt: 1)))
+      #expect((0...4).contains(config.delay(forAttempt: 3)))
+      #expect((0...30).contains(config.delay(forAttempt: 10)))  // capped at maxDelay
+    }
+  }
+
+  @Test("delay honors a server-provided Retry-After verbatim, without jitter")
+  func delayHonorsRetryAfter() {
+    let config = RetryConfig(baseDelay: 1, maxDelay: 30)
+    #expect(config.delay(forAttempt: 1, retryAfter: 12.5) == 12.5)
+    // Server instruction wins even beyond maxDelay.
+    #expect(config.delay(forAttempt: 1, retryAfter: 60) == 60)
+  }
+
+  @Test("retryAfterSeconds parses delta-seconds and rejects HTTP-dates and garbage")
+  func retryAfterParsing() {
+    #expect(RetryConfig.retryAfterSeconds(from: "30") == 30)
+    #expect(RetryConfig.retryAfterSeconds(from: " 5 ") == 5)
+    #expect(RetryConfig.retryAfterSeconds(from: "1.5") == 1.5)
+    #expect(RetryConfig.retryAfterSeconds(from: "Wed, 21 Oct 2026 07:28:00 GMT") == nil)
+    #expect(RetryConfig.retryAfterSeconds(from: "-1") == nil)
+    #expect(RetryConfig.retryAfterSeconds(from: "") == nil)
+  }
+
+  @Test("isTransient classifies URLError codes and respects retriesOnConnectionErrors")
+  func transientClassification() {
+    let config = RetryConfig()
+    #expect(config.isTransient(URLError(.timedOut)))
+    #expect(config.isTransient(URLError(.networkConnectionLost)))
+    #expect(config.isTransient(URLError(.cannotConnectToHost)))
+    #expect(!config.isTransient(URLError(.cancelled)))
+    #expect(!config.isTransient(URLError(.badURL)))
+    #expect(!config.isTransient(ConfigErrors.missingConfig))
+
+    let noConnectionRetries = RetryConfig(retriesOnConnectionErrors: false)
+    #expect(!noConnectionRetries.isTransient(URLError(.timedOut)))
+  }
+}
+
+// MARK: - HTTPClient.send retry-loop tests
+
+struct HTTPClientRetryTests {
+
+  @Test("429 then 200: retries and succeeds on the second attempt")
+  func retriesOn429() async throws {
+    let transport = ScriptedTransport([.status(429), .status(200)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: fastRetry, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 200)
+    #expect(await transport.attemptCount == 2)
+  }
+
+  @Test("503, 503 then 200: keeps retrying while the budget allows")
+  func retriesOn503() async throws {
+    let transport = ScriptedTransport([.status(503), .status(503), .status(200)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: fastRetry, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 200)
+    #expect(await transport.attemptCount == 3)
+  }
+
+  @Test("attempt budget exhausted: the last response is returned unchanged")
+  func budgetExhausted() async throws {
+    let transport = ScriptedTransport([.status(503), .status(503), .status(503)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: fastRetry, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 503)
+    #expect(await transport.attemptCount == 3)  // == maxAttempts
+  }
+
+  @Test("nil retry config performs exactly one attempt (historical behavior)")
+  func nilConfigSingleAttempt() async throws {
+    let transport = ScriptedTransport([.status(503), .status(200)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: nil, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 503)
+    #expect(await transport.attemptCount == 1)
+  }
+
+  @Test("non-retryable status (400) is returned immediately")
+  func nonRetryableStatus() async throws {
+    let transport = ScriptedTransport([.status(400), .status(200)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: fastRetry, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 400)
+    #expect(await transport.attemptCount == 1)
+  }
+
+  @Test("transient URLError (timedOut) is retried; the request eventually succeeds")
+  func transientErrorRetried() async throws {
+    let transport = ScriptedTransport([.failure(URLError(.timedOut)), .status(200)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: fastRetry, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 200)
+    #expect(await transport.attemptCount == 2)
+  }
+
+  @Test("transient errors on every attempt: the last error is rethrown")
+  func transientErrorsExhaustBudget() async throws {
+    let transport = ScriptedTransport([.failure(URLError(.timedOut)), .failure(URLError(.timedOut)), .failure(URLError(.timedOut))])
+    await #expect(throws: URLError.self) {
+      _ = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: fastRetry, logger: logger)
+    }
+    #expect(await transport.attemptCount == 3)
+  }
+
+  @Test("non-transient error (cancelled) is rethrown immediately, no retry")
+  func nonTransientErrorRethrown() async throws {
+    let transport = ScriptedTransport([.failure(URLError(.cancelled)), .status(200)])
+    await #expect(throws: URLError.self) {
+      _ = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: fastRetry, logger: logger)
+    }
+    #expect(await transport.attemptCount == 1)
+  }
+
+  @Test("every attempt is signed afresh from the pristine request")
+  func resignsEveryAttempt() async throws {
+    let signer = CountingSigner()
+    let transport = ScriptedTransport([.status(503), .status(503), .status(200)])
+    _ = try await HTTPClient.scripted(transport).send(makeRequest(), signer: signer, retry: fastRetry, logger: logger)
+
+    #expect(signer.signCount == 3)
+    let stamps = await transport.requests.map { $0.value(forHTTPHeaderField: "X-Test-Attempt") }
+    // Each attempt carries exactly its own stamp — proof the signature was
+    // rebuilt from the unsigned request rather than replayed or layered.
+    #expect(stamps == ["attempt-1", "attempt-2", "attempt-3"])
+  }
+
+  @Test("401 with a refreshable signer: forces one refresh and retries once, even with retry disabled")
+  func refreshesOn401() async throws {
+    let signer = RefreshCountingSigner()
+    let transport = ScriptedTransport([.status(401), .status(200)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: signer, retry: nil, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 200)
+    #expect(await transport.attemptCount == 2)
+    #expect(signer.refreshCount == 1)
+  }
+
+  @Test("second consecutive 401 is returned as-is — refresh-and-retry happens only once")
+  func secondConsecutive401Returned() async throws {
+    let signer = RefreshCountingSigner()
+    let transport = ScriptedTransport([.status(401), .status(401)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: signer, retry: fastRetry, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 401)
+    #expect(await transport.attemptCount == 2)
+    #expect(signer.refreshCount == 1)
+  }
+
+  @Test("401 with a non-refreshable signer is returned immediately")
+  func noRefreshForPlainSigner() async throws {
+    let transport = ScriptedTransport([.status(401), .status(200)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: fastRetry, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 401)
+    #expect(await transport.attemptCount == 1)
+  }
+
+  @Test("Retry-After response header is honored on a 429")
+  func retryAfterHonored() async throws {
+    let transport = ScriptedTransport([
+      .response(status: 429, headers: ["Retry-After": "0"], body: Data()),
+      .status(200),
+    ])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: PlainSigner(), retry: fastRetry, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 200)
+    #expect(await transport.attemptCount == 2)
+  }
+
+  @Test("unsigned requests (signer: nil) go through the retry loop without an Authorization header")
+  func unsignedRequestRetries() async throws {
+    let transport = ScriptedTransport([.status(503), .status(200)])
+    let (_, response) = try await HTTPClient.scripted(transport).send(makeRequest(), signer: nil, retry: fastRetry, logger: logger)
+
+    #expect((response as? HTTPURLResponse)?.statusCode == 200)
+    #expect(await transport.attemptCount == 2)
+    let authHeaders = await transport.requests.map { $0.value(forHTTPHeaderField: "Authorization") }
+    #expect(authHeaders == [nil, nil])
+  }
+}

--- a/Tests/Services/ObjectStorageRetryTests.swift
+++ b/Tests/Services/ObjectStorageRetryTests.swift
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oci-swift-sdk open source project
+//
+// Copyright (c) 2026 Ilia Sazonov and the oci-swift-sdk project authors
+// Licensed under MIT License
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of oci-swift-sdk project authors
+//
+// SPDX-License-Identifier: MIT License
+//
+//===----------------------------------------------------------------------===//
+//
+// End-to-end proof that ObjectStorageClient honors its retryConfig — the core
+// retry loop itself is covered in Tests/OCIKit/RetryTests.swift. Hermetic: a
+// scripted transport plays a canned response per attempt; no credentials, no
+// network.
+//
+
+import Foundation
+import OCIKit
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+private struct StubSigner: Signer {
+  func sign(_ req: inout URLRequest) throws {
+    req.setValue(#"Signature version="1""#, forHTTPHeaderField: "Authorization")
+  }
+}
+
+/// Plays one `(status, body)` per attempt and counts the attempts.
+private actor ScriptedResponses {
+  private var script: [(status: Int, body: Data)]
+  private(set) var attemptCount = 0
+
+  init(_ script: [(status: Int, body: Data)]) { self.script = script }
+
+  func next(for request: URLRequest) throws -> (Data, URLResponse) {
+    attemptCount += 1
+    guard !script.isEmpty else { throw URLError(.unsupportedURL) }
+    let step = script.removeFirst()
+    let response = HTTPURLResponse(url: request.url!, statusCode: step.status, httpVersion: "HTTP/1.1", headerFields: [:])!
+    return (step.body, response)
+  }
+}
+
+private let errorBody = Data(#"{"code":"ServiceUnavailable","message":"please retry"}"#.utf8)
+private let fastRetry = RetryConfig(maxAttempts: 3, baseDelay: 0.001, maxDelay: 0.005)
+
+private func makeClient(script: ScriptedResponses, retryConfig: RetryConfig?) throws -> ObjectStorageClient {
+  let http = HTTPClient { request in try await script.next(for: request) }
+  return try ObjectStorageClient(region: .iad, signer: StubSigner(), retryConfig: retryConfig, httpClient: http)
+}
+
+struct ObjectStorageRetryTests {
+
+  @Test("getNamespace succeeds after a 503 when the client has a retryConfig")
+  func clientLevelRetry() async throws {
+    let script = ScriptedResponses([
+      (503, errorBody),
+      (200, Data(#""frjfldcyl3la""#.utf8)),
+    ])
+    let client = try makeClient(script: script, retryConfig: fastRetry)
+
+    let namespace = try await client.getNamespace()
+
+    #expect(namespace == "frjfldcyl3la")
+    #expect(await script.attemptCount == 2)
+  }
+
+  @Test("without a retryConfig a 503 fails on the first attempt (historical behavior)")
+  func noConfigNoRetry() async throws {
+    let script = ScriptedResponses([
+      (503, errorBody),
+      (200, Data(#""frjfldcyl3la""#.utf8)),
+    ])
+    let client = try makeClient(script: script, retryConfig: nil)
+
+    await #expect(throws: ObjectStorageError.self) {
+      _ = try await client.getNamespace()
+    }
+    #expect(await script.attemptCount == 1)
+  }
+
+  @Test("per-operation retryConfig overrides the client-level configuration")
+  func perOperationOverride() async throws {
+    let script = ScriptedResponses([
+      (503, errorBody),
+      (204, Data()),
+    ])
+    // Client would retry three times, but the call disables retries.
+    let client = try makeClient(script: script, retryConfig: fastRetry)
+
+    await #expect(throws: ObjectStorageError.self) {
+      try await client.deleteObject(
+        namespaceName: "frjfldcyl3la",
+        bucketName: "test_bucket_by_sdk",
+        objectName: "greeting.txt",
+        retryConfig: RetryConfig(maxAttempts: 1)
+      )
+    }
+    #expect(await script.attemptCount == 1)
+  }
+
+  @Test("PAR operations (unsigned) also retry through the client retryConfig")
+  func parOperationRetries() async throws {
+    let payload = Data("Hello, OCI!".utf8)
+    let script = ScriptedResponses([
+      (503, errorBody),
+      (200, payload),
+    ])
+    let client = try makeClient(script: script, retryConfig: fastRetry)
+
+    let data = try await client.getObject(
+      parURL: URL(string: "https://objectstorage.us-ashburn-1.oraclecloud.com/p/token/n/ns/b/bucket/o/")!,
+      objectName: "greeting.txt"
+    )
+
+    #expect(data == payload)
+    #expect(await script.attemptCount == 2)
+  }
+}


### PR DESCRIPTION
Closes #78.

## What

`RetryConfig` was a two-field stub parked at the bottom of `ObjectStorage.swift` that every client stored but nothing read. This PR moves it into `Sources/OCIKit/core/` and implements retries centrally, so all four clients (`ObjectStorageClient`, `SecretsClient`, `IAMClient`, `ContainerInstancesClient`) get consistent behavior.

## Design

**`RetryConfig`** mirrors the Python SDK's `DEFAULT_RETRY_STRATEGY`: 8 total attempts, exponential backoff with **full jitter** (1 s base, 2× growth, 30 s per-sleep cap, 600 s cumulative budget), retryable status codes `429/500/502/503/504`, plus transient `URLError` retries (timeouts, dropped connections, DNS failures). `nil` still means no retries — the historical behavior and the Python SDK default.

**`HTTPClient.send(_:signer:retry:logger:)`** is the shared execution path: the retry loop wraps **sign → send**, and every attempt re-signs the *pristine* request. Per the design discussion on #78, replaying signed bytes would fall outside OCI's ±5-minute clock-skew window after a long backoff, and instance/resource-principal tokens can rotate between attempts — re-signing per attempt rides through both. A parseable `Retry-After` header (delta-seconds) overrides the computed backoff. When the budget is exhausted the last response is returned unchanged, so each operation's existing status handling still produces its service-specific error.

**401 handling**: the new `RefreshableSigner` protocol (`forceRefresh()`) gets one immediate force-refresh-and-retry outside the retry budget — it works even with retries disabled. `ResourcePrincipalSigner` already had `forceRefresh()`; `X509FederationClientBasedSecurityTokenSigner` and `InstancePrincipalSigner` now conform via a new `X509FederationClientProtocol.forceRefresh()` requirement (defaulted to a no-op, so external conformers keep compiling). `APIKeySigner`/`SecurityTokenSigner` intentionally do not conform — a 401 is not recoverable there.

**Per-operation override**: every ObjectStorage operation now accepts `retryConfig: RetryConfig? = nil` (the docs on ~30 of them already promised it). `nil` inherits the client-level config; `RetryConfig(maxAttempts: 1)` disables retries for a single call. PAR operations retry too (unsigned, `signer: nil`).

**Transport seam**: `IAMClient` and `ContainerInstancesClient` gain the injectable `httpClient: HTTPClient = .live` parameter that ObjectStorage/Secrets already had, replacing their direct `URLSession.shared` calls.

All sleeping uses `Task.sleep` — no GCD, no blocking primitives.

## Tests

Hermetic, credential-free, offline — added to `UNIT_TEST_FILTER`:

- **`RetryConfigTests`** — defaults, jitter bounds, `Retry-After` parsing, transient-error classification.
- **`HTTPClientRetryTests`** — scripted transport asserting attempt counts (429/503→200, budget exhaustion, nil config, non-retryable status, transient vs. non-transient errors), per-attempt re-signing (attempt-stamped signatures), and 401 refresh-once semantics.
- **`ObjectStorageRetryTests`** — end-to-end wiring: client-level retry on `getNamespace`, per-op override on `deleteObject`, unsigned PAR retry.

## Verification

- macOS: `swift build --build-tests` clean (no new warnings); full CI unit filter passes (90 tests / 20 suites).
- Linux (`swift:6.2` container): `swift build --build-tests` clean; same 90 tests pass.
- Touched files formatted with `swift format`; remaining lint warnings in `InstancePrincipalSigner` are pre-existing constant-naming ones.

Noticed while wiring IAM (left out of scope): several IAM operations throw `ObjectStorageError` instead of `IAMError` — filed as #80.
