### PR TITLE
Docs: mark observability done, split the backend guides, add a Skills index

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,68 +23,21 @@ Support for OCI services is being added incrementally, starting with those curre
 - [x] AI Language (health entity detection)
 - [x] Functions — run Swift as a function (FDK) + invoke a function
 - [x] Logging Ingestion (`PutLogs`) + a batching swift-log backend
+- [x] Monitoring (`PostMetricData`) + a swift-metrics backend
 
 ## Logging backend
 
 `OCILogHandler` is a [swift-log](https://github.com/apple/swift-log) backend that ships your
-application's log records to an OCI [custom log](https://docs.oracle.com/en-us/iaas/Content/Logging/Concepts/custom_logs.htm).
-Bootstrap it once and the rest of the code keeps using plain `Logger` values.
+application's log records to an OCI [custom log](https://docs.oracle.com/en-us/iaas/Content/Logging/Concepts/custom_logs.htm)
+with `PutLogs`: bootstrap it once and the rest of the code keeps using plain `Logger` values,
+while an actor batches records in the background so `log(...)` never blocks and never performs
+I/O. Reach for it wherever the platform will not collect your logs for you — Container
+Instances, Compute shapes the Logging agent does not cover, or any process whose records must
+land in Logging without a file on disk in between.
 
-```swift
-import Logging
-import OCIKit
-
-let signer = try APIKeySigner(configFilePath: "~/.oci/config")
-let batcher = try OCILogBatcher(
-  configuration: OCILogHandlerConfiguration(
-    logId: "ocid1.log.oc1.phx.EXAMPLE",   // an existing custom log
-    type: "com.example.orders"
-  ),
-  region: .phx,
-  signer: signer
-)
-
-LoggingSystem.bootstrap { label in
-  MultiplexLogHandler([
-    StreamLogHandler.standardOutput(label: label),
-    OCILogHandler(label: label, batcher: batcher),
-  ])
-}
-
-Logger(label: "com.example.orders").info("order placed", metadata: ["orderId": "1234"])
-
-// Before the process exits, so buffered records are not lost:
-await batcher.shutdown()
-```
-
-`log(...)` never blocks and never performs I/O: it renders the record and hands it to a bounded
-buffer. An `OCILogBatcher` actor drains that buffer and uploads batches with `PutLogs` — on a size
-threshold (1 MiB), on an interval (5 s), or when you call `flush()`/`shutdown()` — keeping at most
-one request in flight. Messages longer than the service's 10,000-character truncation point are
-split across entries. Anything logged from *inside* a flush is dropped rather than shipped —
-whether it comes from the SDK's own logger or from your custom transport, signer, or retry code on
-the request path — so a flush can never generate more logs to flush.
-
-Records are lost in exactly two situations, both counted in `batcher.statistics` (a log backend
-cannot report its own errors through the logging system it implements):
-
-- **The buffer is full.** The newest record is dropped and counted in `statistics.dropped`. Raise
-  `bufferCapacity` if you see this.
-- **The backlog outgrows the buffer.** A failed flush is *not* discarded: its entries go back into
-  the buffer and the next flush retries them, so records survive an outage (the service accepts
-  entries as old as the log's retention window). Only when that backlog exceeds `bufferCapacity`
-  are the oldest entries dropped, counted in `statistics.failed`. `statistics.flushFailures` and
-  `statistics.lastFlushErrorDescription` report failures that were retried successfully too.
-
-`shutdown()` waits for the final upload, so give it room in your termination grace period: at
-worst `retryConfig.maxAttempts × requestTimeout + retryConfig.maxCumulativeDelay`, which is 40 s
-with the defaults. Shorten `requestTimeout` or `retryConfig` if that is too long. A batch whose
-*final* flush fails is lost, since nothing is left to retry it.
-
-The log group and the log are control-plane resources: create them with Terraform, the OCI
-Console, or the CLI, and pass the log's OCID. Your principal needs
-`allow ... to use log-content in compartment ...`. To call `PutLogs` directly, use
-`LoggingIngestClient`.
+See [`docs/logging-backend.md`](docs/logging-backend.md) for prerequisites and IAM, the
+bootstrap composition, the full configuration surface, flushing and shutdown, the two ways
+records can be lost, and how to confirm delivery.
 
 ## OCI Functions
 
@@ -98,37 +51,16 @@ and invoking functions.
 ## Metrics backend
 
 `OCIMetricsFactory` is a [swift-metrics](https://github.com/apple/swift-metrics) backend that
-publishes an application's metrics to [OCI Monitoring](https://docs.oracle.com/en-us/iaas/Content/Monitoring/Tasks/publishingcustommetrics.htm)
-as custom metrics. Counters, gauges, recorders and timers are aggregated in process and posted
-with `PostMetricData` on a 60-second step; requests are split at the service's 50-stream limit,
-dimensions are sanitized, a default dimension is synthesized for metrics that have none, and data
-points that age past the service's two-hour window are dropped and counted rather than retried.
+publishes an application's `Counter`, `Gauge`, `Recorder` and `Timer` instruments to
+[OCI Monitoring](https://docs.oracle.com/en-us/iaas/Content/Monitoring/Tasks/publishingcustommetrics.htm)
+as custom metrics — aggregated in process and posted with `PostMetricData` on a 60-second step,
+where they become queryable, chartable and alarmable next to the platform's own `oci_*` metrics.
+Reach for it whenever you want application-level numbers such as request rates, queue depths or
+handler latencies: no OCI runtime collects those for you, so self-export is the only path.
 
-```swift
-import CoreMetrics
-import OCIKit
-
-let client = try MonitoringClient(region: .phx, signer: signer)
-let factory = OCIMetricsFactory(
-  client: client,
-  configuration: try OCIMetricsConfiguration(
-    namespace: "my_app",
-    compartmentId: compartmentId,
-    commonDimensions: ["service": "checkout", "env": "prod"]
-  )
-)
-await factory.start()
-MetricsSystem.bootstrap(factory)
-
-// before the process exits, so the last step is not lost:
-await factory.shutdown()
-```
-
-The SDK never calls `MetricsSystem.bootstrap` itself — the application owns the process-global
-system and is free to multiplex this backend with another. The caller's principal needs
-`allow ... to use metrics in compartment ...`, optionally narrowed with
-`where target.metrics.namespace='<namespace>'`. Nothing on the export path throws; what was
-published and what was lost is reported by `await factory.statistics()`.
+See [`docs/metrics-backend.md`](docs/metrics-backend.md) for prerequisites and IAM, the
+bootstrap composition, the configuration surface, what each instrument becomes on the wire,
+shutdown, and how to confirm the metrics arrived.
 
 ## Deployment guide
 
@@ -138,6 +70,39 @@ distribute an APM data key — see
 [`docs/observability-deployment.md`](docs/observability-deployment.md). The tracing recipe
 (swift-otel → OCI APM) is a standalone worked example in
 [`Examples/apm-tracing`](Examples/apm-tracing/README.md).
+
+## Skills
+
+The [`.claude/skills/`](.claude/skills/) directory holds *agent skills*: packaged instructions
+that an AI coding agent (Claude Code and compatible tools) loads on demand while working in this
+repository, so that recurring jobs — adding a service client, recording a fixture, wiring up a
+backend — follow this project's conventions instead of being reinvented each time. Each skill is
+a single `SKILL.md`, and the description at the top of that file is what decides when it fires.
+They are useful reading for humans too: each one is the long-form version of a workflow this
+README can only summarize.
+
+- [`oci-new-service-client`](.claude/skills/oci-new-service-client/SKILL.md) — scaffolds a
+  brand-new OCI service client (router enum, client struct wired to the `HTTPClient` seam,
+  `Codable` models, error enum) following the Container Instances reference implementation, then
+  instruments it with credential-free unit tests and hermetic wire tests. Fires on "implement a
+  new OCI service", "add the `<X>` client", "port `<X>` from the Python SDK".
+- [`oci-capture-fixtures`](.claude/skills/oci-capture-fixtures/SKILL.md) — captures a real OCI
+  wire response, and the request that produced it, into a committable JSON fixture under
+  `Tests/Services/Fixtures`, using a live OCI config profile. Fires on "capture a real OCI
+  response", "record a fixture from OCI", "grab the real wire response" for an operation.
+- [`oci-wire-tests`](.claude/skills/oci-wire-tests/SKILL.md) — turns those fixtures into a
+  hermetic replay suite that asserts request building and response decoding with no credentials
+  and no network. Fires on "write wire tests for `<service>`", "add replay tests", "hermetic
+  tests for `<operation>`".
+- [`oci-logging-backend`](.claude/skills/oci-logging-backend/SKILL.md) — enables `OCILogHandler`
+  end to end: prerequisites and IAM, the `LoggingSystem.bootstrap` composition, the full
+  `OCILogHandlerConfiguration` surface, batcher lifecycle and shutdown flushing, and how to tell
+  whether delivery actually works. Fires on "ship my app logs to OCI Logging", "set up
+  OCILogHandler", "my logs never show up in OCI Logging".
+- [`oci-metrics-backend`](.claude/skills/oci-metrics-backend/SKILL.md) — enables
+  `OCIMetricsFactory` end to end: construction, `MetricsSystem.bootstrap`, the configuration
+  surface, IAM, shutdown and verification. Fires on "send my metrics to OCI Monitoring",
+  "publish custom metrics from Swift", "why are my metrics not showing up in Monitoring".
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -62,14 +62,28 @@ See [`docs/metrics-backend.md`](docs/metrics-backend.md) for prerequisites and I
 bootstrap composition, the configuration surface, what each instrument becomes on the wire,
 shutdown, and how to confirm the metrics arrived.
 
+## Tracing
+
+Traces are the one signal with **no OCIKit client, deliberately**. OCI
+[APM](https://docs.oracle.com/en-us/iaas/application-performance-monitoring/home.htm) ingests
+OpenTelemetry natively: its collector accepts OTLP/HTTP authenticated with
+`Authorization: dataKey <key>` rather than an OCI request signature, so any stock OTLP exporter
+— [swift-otel](https://github.com/swift-otel/swift-otel), typically — can post spans to an APM
+domain unmodified. There is nothing for this SDK to sign, and so nothing for it to wrap.
+
+[`Examples/apm-tracing`](Examples/apm-tracing/README.md) is a standalone, runnable worked
+example of that recipe (a plain service and an OCI Functions variant), with the endpoint layout,
+data-key handling, and the caveats that bite — span links are dropped, there is no OTLP logs
+endpoint, and Always Free is capped at 1,000 tracing events per hour. On Functions the platform
+injects the collector URL and B3 trace context at runtime; `OCIKitFunctions` surfaces both
+through `TracingContext` and `APMCollectorEndpoint`.
+
 ## Deployment guide
 
 For per-runtime guidance — which signer to construct on a VM, OKE, Container Instances, or
 Functions; copy-paste IAM policies for logs and metrics; Always Free specifics; and how to
 distribute an APM data key — see
-[`docs/observability-deployment.md`](docs/observability-deployment.md). The tracing recipe
-(swift-otel → OCI APM) is a standalone worked example in
-[`Examples/apm-tracing`](Examples/apm-tracing/README.md).
+[`docs/observability-deployment.md`](docs/observability-deployment.md).
 
 ## Skills
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,9 @@
 *Audit date: July 2026. Method: a multi-agent audit of all 171 modules in the reference
 Python SDK (`oci-python-sdk`), triaged against this project's focus, with a deep dive into
 every module that survived triage (23 candidates). Priorities below reflect maintainer
-review of the audit (2026-07-16).*
+review of the audit (2026-07-16). Work that has since shipped keeps its entry in place,
+marked **shipped** with a date, and is also listed under **Already implemented** — the audit
+verdicts stay readable, the inventory stays current.*
 
 ## Guiding principle
 
@@ -36,44 +38,64 @@ Two recurring OCI nuances shaped this audit:
 
 | Verdict | Count |
 |---|---|
-| Tier 1 — high priority | 3 |
+| Tier 1 — high priority | 3 (1 shipped 2026-07) |
 | Tier 2 — medium priority | 2 |
-| Backlog — low priority | 16 |
-| Already implemented | 7 services + auth signers |
+| Backlog — low priority | 16 (1 partially shipped 2026-07) |
+| Already implemented | 9 services + auth signers |
 | Control-plane only (excluded) | 109 modules |
 | Low value (excluded, reasons below) | 29 modules |
 | Not a service (helpers) | 3 modules |
 
 **Already implemented:** ObjectStorage, Secrets (bundle retrieval), AI Language,
 Generative AI Inference, IAM/Identity (partial), Container Instances, Functions (invoke
-client + the `OCIKitFunctions` FDK) — plus the auth core: API key signer, instance
-principal, resource principal v2.2, OKE workload identity, security token signer.
+client + the `OCIKitFunctions` FDK), Logging Ingestion (`putLogs` + the `OCILogHandler`
+swift-log backend), Monitoring (ingestion only — `postMetricData` + the `OCIMetricsFactory`
+swift-metrics backend; the query ops stay in the backlog) — plus the auth core: API key
+signer, instance principal, resource principal v2.2, OKE workload identity, security token
+signer.
 
 ---
 
 ## Tier 1 — High priority
 
-### 1. Logging Ingestion (`loggingingestion`) + swift-log backend
+### 1. Logging Ingestion (`loggingingestion`) + swift-log backend — shipped 2026-07
 
+- **Status: shipped 2026-07** (observability initiative, epic #85 —
+  [OBSERVABILITY.md](OBSERVABILITY.md)), live-verified against a real tenancy and a real OKE
+  cluster. Still open from that epic: the swift-log 1.14 / `LogEvent` follow-up (#87). Not in
+  scope and still backlog: Logging Search, Log Analytics.
 - **Ops (1):** `putLogs` — push batched `LogEntry` records to a Custom Log OCID.
-- **Why:** today a Swift service on OCI has no first-party way to get structured logs into
-  OCI Logging/Log Search/Alarms except stdout-scraping by the platform agent.
-- **The deliverable is two layers, and the second is essential:**
-  1. the raw `putLogs` client (one op, three tiny models);
+- **Why:** before this landed, a Swift service on OCI had no first-party way to get
+  structured logs into OCI Logging/Log Search/Alarms except stdout-scraping by the platform
+  agent.
+- **The deliverable was two layers, and the second was the essential one — both shipped:**
+  1. the raw `putLogs` client (`LoggingIngestClient`, one op, three tiny models);
   2. an **`OCILogHandler`: a swift-log `LogHandler` backend** that batches log records
-     in-memory and flushes them to `putLogs` on a size/interval threshold (plus explicit
-     flush on shutdown). This is what makes adoption zero-friction — apps already using
-     swift-log (including this SDK itself) point their `LoggingSystem` bootstrap at OCI and
-     are done. Design attention: the handler must not log its own failures recursively, and
-     flushing must be actor-isolated (no GCD).
-- **Cost/quirks:** dedicated host `ingestion.logging.{region}` — needs its own entry in
-  `Region+Service.swift`. The `logging` (log-group CRUD) module stays out of scope.
+     in-memory (in the `OCILogBatcher` actor) and flushes them to `putLogs` on a
+     size/interval threshold, plus an explicit flush on shutdown. This is what makes adoption
+     zero-friction — apps already using swift-log (including this SDK itself) point their
+     `LoggingSystem` bootstrap at OCI and are done. Design attention, as required: the
+     handler does not log its own failures recursively, and flushing is actor-isolated
+     (no GCD).
+- **Cost/quirks:** dedicated host `ingestion.logging.{region}` — shipped as its own
+  `.loggingingestion` case in `Region+Service.swift`. The `logging` (log-group CRUD) module
+  stays out of scope.
 - **Expanded 2026-07 by the observability initiative ([OBSERVABILITY.md](OBSERVABILITY.md),
-  #85):** ships together with the promoted Monitoring `postMetricData` slice + an
+  #85):** shipped together with the promoted Monitoring `postMetricData` slice + an
   `OCIMetricsFactory` swift-metrics backend (decisions recorded there, incl. the approved
-  `swift-metrics` core dependency). Tracing needs no client — OCI APM ingests OTLP/HTTP with
-  data-key auth; the deliverable is a documented swift-otel recipe plus `OCIKitFunctions`
-  tracing-context fixes (#86).
+  `swift-metrics` core dependency, now in `Package.swift`). The rest of Monitoring stays
+  backlog.
+- **Tracing needed no client, and none was built.** OCI APM ingests OTLP/HTTP with
+  `Authorization: dataKey` auth (not OCI-signed), so the deliverable was a documented
+  swift-otel recipe rather than a service client — shipped as
+  [docs/observability-deployment.md](docs/observability-deployment.md) (per-runtime guide:
+  which signer, which IAM policy, which endpoint) plus the standalone
+  [Examples/apm-tracing](Examples/apm-tracing) package, where swift-otel is an example-only
+  dependency the SDK itself never takes. SDK-side work was limited to the `OCIKitFunctions`
+  tracing-context fixes (#86): raw invocation headers, `TracingContext`, and the
+  `APMCollectorEndpoint` collector-URL parser. The original audit could not surface the APM
+  upload endpoint at all, because it is not a module in any language SDK; APM trace *query*
+  remains excluded (see Excluded section).
 
 ### 2. Email Delivery — Data Plane (`email_data_plane`)
 
@@ -179,16 +201,14 @@ audit findings so they can be picked up without re-research.
 
 - **Monitoring (`monitoring`)** — `postMetricData` / `summarizeMetricsData` / `listMetrics`
   (3 of 18 ops; ingestion host differs: `telemetry-ingestion.*` vs `telemetry.*`).
-  **`postMetricData` promoted to Tier 1 (2026-07, observability initiative — see
-  [OBSERVABILITY.md](OBSERVABILITY.md))**; `summarizeMetricsData`/`listMetrics` and the
-  `telemetry.*` query host remain backlog.
-- **APM OTLP ingest (traces/metrics)** — needs no OCIKit client: the APM collector accepts
-  OTLP/HTTP with `Authorization: dataKey` auth (not OCI-signed), so the deliverable is a
-  documented swift-otel recipe (see [OBSERVABILITY.md](OBSERVABILITY.md)). The original audit
-  could not surface this endpoint because it is not a module in any language SDK. APM trace
-  *query* remains excluded (see Excluded section).
-- **Logging Search (`loggingsearch`)** — one op, `searchLogs`; trivial companion to Logging
-  Ingestion when an ops-tooling story materializes.
+  **`postMetricData` shipped 2026-07** with the observability initiative (Tier 1 #1 above —
+  `MonitoringClient` + `OCIMetricsFactory`, see [OBSERVABILITY.md](OBSERVABILITY.md));
+  `summarizeMetricsData`/`listMetrics` and the `telemetry.*` query host **remain backlog** —
+  a dashboard/alarm-query surface, not app runtime, so they stay demand-gated. The module
+  keeps its backlog entry for that unshipped half.
+- **Logging Search (`loggingsearch`)** — one op, `searchLogs`; trivial companion to the
+  now-shipped Logging Ingestion client when an ops-tooling story materializes. Unchanged by
+  the 2026-07 observability work.
 - **Log Analytics (`log_analytics`)** — only the curated slice (~9 of ~180 ops: three upload
   endpoints incl. an OTLP logs sink, plus query). Premium opt-in service, heavy onboarding.
 
@@ -228,7 +248,9 @@ audit findings so they can be picked up without re-research.
 - **Ops/admin/billing tooling (29 low-value modules):** audit event export, APM trace query,
   usage/cost APIs (`usage_api`, `osub_*`, `osp_gateway`), threat intelligence, announcements,
   support tickets (`cims`), vulnerability scanning, management dashboards — genuine read APIs,
-  but for dashboards/SIEM/finance, not app runtime.
+  but for dashboards/SIEM/finance, not app runtime. (Only APM trace *query* is excluded; APM
+  trace *ingest* is a separate, data-key-authenticated OTLP endpoint and shipped 2026-07 as a
+  documented recipe — see Tier 1 #1.)
 - **`oda` (Digital Assistant):** authoring/lifecycle only; no runtime chat endpoint exists in
   the Python module. Runtime chat for agents is covered by `generative_ai_agent_runtime`.
 - **`encryption`:** a client-side crypto helper library in Python, not a REST service. A
@@ -244,10 +266,12 @@ audit findings so they can be picked up without re-research.
    built — use per-resource data-plane hosts. The `SecretsClient`-style `endpoint:` override
    is the right precedent — do **not** pull in control-plane clients just to resolve
    endpoints.
-2. **New `Region+Service` entries needed** for dedicated hosts:
-   `ingestion.logging.*`, `cell0.submit.email.*`, `auth.*` (identity data plane — already
-   partially present via the federation client); later `telemetry-ingestion.*`/`telemetry.*`,
-   `generic.artifacts.*`, `query.*`.
+2. **New `Region+Service` entries needed** for dedicated hosts: `cell0.submit.email.*`,
+   `auth.*` (identity data plane — already partially present via the federation client);
+   later `telemetry.*` (Monitoring query), `generic.artifacts.*`, `query.*`. Added 2026-07:
+   `ingestion.logging.*` (case `.loggingingestion`) and `telemetry-ingestion.*` (case
+   `.monitoringingestion` — no `.oci.` segment, the same suffix divergence `objectstorage`
+   already had).
 3. **SSE response streaming: deliberately dropped.** OCI streams LLM responses as
    Server-Sent Events when `isStream: true` is set (the shipped generativeai client exposes
    the flag but buffers via `URLSession.shared.data(for:)`, so incremental delivery can't
@@ -274,7 +298,7 @@ audit findings so they can be picked up without re-research.
 | Phase | Work | Rationale |
 |---|---|---|
 | 1 | Spike: stomp-nio ↔ OCI Queue recipe | Small surface, high leverage; validates the Queue-without-REST bet early |
-| 2 | Observability ([OBSERVABILITY.md](OBSERVABILITY.md)): Logging Ingestion + `OCILogHandler`, Monitoring `postMetricData` + `OCIMetricsFactory`; Email Data Plane | Production server-app table stakes: logs, metrics, transactional email |
+| 2 | Observability ([OBSERVABILITY.md](OBSERVABILITY.md)): Logging Ingestion + `OCILogHandler`, Monitoring `postMetricData` + `OCIMetricsFactory`, APM tracing recipe — **shipped 2026-07**. Remaining in this phase: Email Data Plane | Production server-app table stakes: logs, metrics, transactional email — logs and metrics landed, email is what's left |
 | 3 | Identity Data Plane (+ `SecurityTokenSigner` self-refresh integration) | Fixes a real limitation in shipped auth |
 | 4 | KMS Crypto, Certificates | Security round-out (small, Secrets-shaped) |
 | 5 | Backlog by demand (incl. swift-kafka-client ↔ Streaming recipe) | Audience-gated work |

--- a/docs/logging-backend.md
+++ b/docs/logging-backend.md
@@ -1,0 +1,349 @@
+# Logging backend: swift-log → OCI Logging
+
+`OCILogHandler` is a [swift-log](https://github.com/apple/swift-log) backend that ships your
+application's log records to an OCI
+[custom log](https://docs.oracle.com/en-us/iaas/Content/Logging/Concepts/custom_logs.htm).
+Bootstrap it once at start-up and the rest of the code keeps using plain `Logger` values —
+nothing downstream of the bootstrap knows OCI is involved.
+
+Reach for it when the platform will not collect your logs for you: **Container Instances**
+(no agent, no sidecar — the platform's `RetrieveLogs` is view-only), **Compute E2.1.Micro**
+(the Logging agent plugin is shape-gated), **OKE** where you'd rather ship structured records
+than tail `/var/log/containers/*`, or any process whose records must land in Logging without a
+file on disk in between. On Functions the platform already captures stdout/stderr, so the
+handler is worth adding only for records you want under your own log OCID and `type`.
+
+- Per-runtime signer choice and copy-paste IAM policies:
+  [`observability-deployment.md`](observability-deployment.md) §2–§3.
+- The metrics half of the same story: [`metrics-backend.md`](metrics-backend.md).
+- Wire-level research behind every limit quoted here: [`../OBSERVABILITY.md`](../OBSERVABILITY.md) §2.1.
+- Source of truth: [`../Sources/OCIKit/services/LoggingIngestion/`](../Sources/OCIKit/services/LoggingIngestion/).
+- A deeper, task-oriented version of this guide, packaged for an AI coding agent working in
+  this repo: [`.claude/skills/oci-logging-backend`](../.claude/skills/oci-logging-backend/SKILL.md).
+
+All OCIDs below are placeholders — replace the bracketed/`EXAMPLE` values with your own.
+
+---
+
+## 1. Prerequisites — none of them are checked at runtime
+
+| You need | Why | What happens without it |
+|---|---|---|
+| A **custom log OCID** | `PutLogs` ingests into an existing log; the log group and the log are control-plane resources OCIKit has no client for | The batcher constructs happily and every flush fails **silently** |
+| IAM `LOG_CONTENT_PUSH` | `Allow dynamic-group <dg> to use log-content in compartment <compartment>` | Same — a `404 NotAuthorizedOrNotFound` absorbed into a counter |
+| A **signer** | Ingestion is standard OCI request signing; every OCIKit signer works | `init` throws only for a missing region/endpoint, never for a bad principal |
+
+Create the log group and the log with Terraform, the OCI Console, or the CLI, then pass the
+log's OCID as configuration rather than a literal. On Functions, the resource principal's token
+is cached for ~15 minutes, so a policy edit is not live immediately.
+
+The only thing `OCILogBatcher.init` throws is
+`LoggingIngestionError.missingRequiredParameter` — and only when you supply neither `region:`
+nor `endpoint:`. Everything else fails later, quietly, into `statistics`. That is §5.
+
+---
+
+## 2. Bootstrap
+
+Build the batcher first: swift-log calls the bootstrap closure once per logger label, and every
+handler it creates shares this one batcher.
+
+```swift
+import Logging
+import OCIKit
+
+let signer = try InstancePrincipalSigner()   // or any other signer — see the deployment guide
+
+let batcher = try OCILogBatcher(
+  configuration: OCILogHandlerConfiguration(
+    logId: "ocid1.log.oc1.phx.EXAMPLE",      // an existing custom log
+    type: "com.example.orders"
+  ),
+  region: .phx,                              // or `endpoint:` instead
+  signer: signer
+)
+
+// Keep the console handler: it is how you debug the process when the OCI half is
+// the broken half.
+LoggingSystem.bootstrap { label in
+  MultiplexLogHandler([
+    StreamLogHandler.standardOutput(label: label),
+    OCILogHandler(label: label, batcher: batcher, logLevel: .info),
+  ])
+}
+
+Logger(label: "com.example.orders").info("order placed", metadata: ["orderId": "1234"])
+
+// Before the process exits, so buffered records are not lost:
+await batcher.shutdown()
+```
+
+`import Logging` resolves through OCIKit's own swift-log dependency, so no extra package is
+needed (declaring swift-log in your own manifest is tidier, and harmless).
+
+Two ordering rules:
+
+- **The SDK never calls `LoggingSystem.bootstrap`** — a process-global system belongs to the
+  application, which is free to multiplex this backend with any other. That is also why
+  `MultiplexLogHandler` above is the recommended shape rather than an aside.
+- **Bootstrap before any framework builds its own `Logger`** (Hummingbird, Vapor, your own
+  `Logger` globals). swift-log latches its factory on the first call and traps on a second, so
+  a logger created before the bootstrap keeps the default handler for the life of the process.
+
+`OCILogHandler.init(label:batcher:logLevel:metadata:metadataProvider:)` defaults `logLevel` to
+`.info`, `metadata` to empty, and `metadataProvider` to `nil`.
+
+### What a record looks like on the wire
+
+The handler renders on the caller's thread, in a layout that mirrors swift-log's own
+`StreamLogHandler` so a record read in the OCI Console looks like the record read on the
+console — except the timestamp is RFC3339 (matching the entry's `time`) and there is no
+trailing newline:
+
+```
+2026-07-21T15:49:00.123Z info com.example.orders : orderId=1234 [Orders] order placed
+```
+
+Metadata is merged handler → provider → call-site (increasing precedence) and rendered as
+`key=value` pairs sorted by key, so a record's text is stable across runs. Each `LogEntry`
+carries its own `time` — when the application logged, not when the batch flushed — and the
+batch carries `source`, `type`, `subject`, and a `defaultlogentrytime` of the flush instant.
+
+---
+
+## 3. The configuration surface
+
+Only `logId` is required. Out-of-range values are **clamped, not rejected**, so a bad number
+degrades rather than throwing.
+
+| Parameter | Default | Change it when |
+|---|---|---|
+| `logId` | *(required)* | — |
+| `source` | `defaultSource` — `ProcessInfo.processInfo.hostName` | The hostname is not the identity you want in the Console. **On OKE virtual nodes the hostname is `localhost` for every pod** — take the pod name from the downward API instead |
+| `type` | `defaultType` — `"oci-swift-sdk.application"` | Always: use something that identifies the application, e.g. `"com.example.orders"` |
+| `subject` | `nil` | You want the sub-resource the events came from recorded per batch |
+| `flushInterval` | `5` seconds | This is your ingestion lag. `0` (and any negative value, clamped to `0`) disables the ticker, leaving only the size threshold and explicit `flush()` |
+| `flushSizeThreshold` | `1 << 20` (1 MiB of buffered UTF-8) | Rarely. `PutLogs` accepts 1 MiB → 1 GiB with no silent drops, so this bound is ergonomics — it caps retry amplification and per-flush upload latency |
+| `bufferCapacity` | `10_000` records | `statistics.dropped` is climbing: the buffer is too small for the burst rate |
+| `maxEntryLength` | `9_900` characters (clamped into `1...10_000`) | Rarely — see below |
+| `requestTimeout` | `10` seconds per attempt | You need a tighter or looser bound on `shutdown()`. `0` leaves the transport's own timeout, which for `URLSession` is 60 s |
+| `retryConfig` | `RetryConfig(maxAttempts: 3, baseDelay: 0.5, maxDelay: 5, maxCumulativeDelay: 10)` | Same reason. `nil` performs a single attempt per flush |
+| `excludedLoggerLabels` | `["OCIKit"]` | You have a noisy label to silence. Your set is **unioned** with the default, never replacing it |
+
+```swift
+OCILogHandlerConfiguration(
+  logId: "ocid1.log.oc1.phx.EXAMPLE",
+  source: podName,
+  type: "com.example.orders",
+  subject: "order-service",
+  flushInterval: 5,
+  flushSizeThreshold: 1 << 20,
+  bufferCapacity: 10_000,
+  maxEntryLength: 9_900,
+  requestTimeout: 10,
+  retryConfig: RetryConfig(maxAttempts: 3, baseDelay: 0.5, maxDelay: 5, maxCumulativeDelay: 10),
+  excludedLoggerLabels: ["com.example.noisy"]
+)
+```
+
+Three of these deserve more than a table row.
+
+**`maxEntryLength` exists because the service truncates silently.** Any entry `data` longer
+than 10,000 characters comes back HTTP 200 and is stored cut to exactly 10,000 characters
+ending in `...` (live-verified). The batcher therefore splits longer records into consecutive
+entries client-side, in order, so the parts read contiguously. A consequence:
+`statistics.submitted` counts **entries**, not records.
+
+**`requestTimeout` × `retryConfig` is the bound on `shutdown()`** —
+`maxAttempts × requestTimeout + maxCumulativeDelay`, which is 40 seconds with the defaults.
+Shrink both if your runtime enforces a tighter termination grace period.
+
+**`excludedLoggerLabels` is one half of the recursion guard.** Shipping logs produces logs, and
+a backend that shipped its own would never converge. Three mechanisms keep it from happening,
+and none of them is optional:
+
+1. The batcher's internal `LoggingIngestClient` writes to a private no-op backend, bypassing
+   the bootstrapped `LoggingSystem` entirely, whatever the application bootstrapped.
+2. A task-local `isFlushing` is bound around the `PutLogs` call and inherited by the whole async
+   call tree it drives — a custom `HTTPClient`, a custom `Signer`, retry logic, any third-party
+   code on the request path. Records offered while it is set are discarded, whatever their label.
+3. `excludedLoggerLabels` covers code that logs through the bootstrapped system *outside* a
+   flush — notably the SDK's own global `logger`, label `"OCIKit"`, which the signer writes to
+   on every signing pass. `"OCIKit"` is unioned in by the initializer and re-checked by the
+   batcher, so it cannot be removed.
+
+---
+
+## 4. Flush on shutdown, or lose the buffer
+
+`log(...)` never blocks and never performs I/O: it renders the record and hands it to a bounded
+buffer. The `OCILogBatcher` actor drains that buffer and uploads batches with `PutLogs` — on the
+size threshold, on the interval tick, or when you call `flush()`/`shutdown()` — keeping at most
+one request in flight. `init` starts the drain and ticker tasks immediately, and those tasks
+retain the batcher: **dropping the last reference does not stop it.** `shutdown()` does.
+
+```swift
+await batcher.flush()      // mid-life: upload everything logged before this call
+await batcher.shutdown()   // stop accepting, drain, upload, end both tasks; idempotent
+```
+
+`flush()` waits for records still in transit between `enqueue` and the buffer before uploading,
+so a flush issued right before exit ships them too. `shutdown()` is idempotent; after it
+returns, further records are discarded and counted in `statistics.dropped` — which is expected
+on a clean exit, not a defect.
+
+Skipping `shutdown()` loses up to `bufferCapacity` records, including the ones explaining why
+the process is going away. Drive it from your service lifecycle rather than a signal handler —
+[swift-service-lifecycle](https://github.com/swift-server/swift-service-lifecycle) 2.x is a
+dependency of *your* package; OCIKit does not ship it:
+
+```swift
+import ServiceLifecycle
+
+// Spell `Service` in full — `import OCIKit` also brings one in (the OCI service catalogue).
+struct TelemetryFlushService: ServiceLifecycle.Service {
+  let batcher: OCILogBatcher
+
+  func run() async throws {
+    try await gracefulShutdown()   // parks here until the group starts shutting down
+    await batcher.shutdown()       // waits for the final PutLogs
+  }
+}
+
+// A `ServiceGroup` tears down in REVERSE array order — put the flush service FIRST
+// so it drains LAST, once the server has stopped and logged its final line.
+let group = ServiceGroup(
+  services: [flushService, server],
+  gracefulShutdownSignals: [.sigterm],
+  logger: logger
+)
+```
+
+---
+
+## 5. Failures are never thrown — `statistics` is the only signal
+
+This is the single most confusing thing about the backend, so it is worth stating flatly:
+
+> **Nothing on the export path throws, and nothing on the export path is logged.** A wrong log
+> OCID, a missing `use log-content` policy, an unreachable endpoint, a `429` storm — all of them
+> look exactly like a healthy application from the outside.
+
+The reason is structural: a log backend cannot report its own errors through the logging system
+it implements without producing the very records it just failed to ship. So the batcher swallows
+every failure into counters, and reading them is the *only* way to learn that logs are being
+lost. `batcher.statistics` is a `nonisolated` snapshot — no `await` — so it is cheap to expose
+from a health endpoint or to dump at shutdown.
+
+```swift
+let stats = batcher.statistics
+logger.info(
+  "log delivery",
+  metadata: [
+    "enqueued": .stringConvertible(stats.enqueued),          // accepted into the hand-off buffer
+    "submitted": .stringConvertible(stats.submitted),        // entries the service accepted
+    "dropped": .stringConvertible(stats.dropped),            // buffer full, or logged post-shutdown
+    "failed": .stringConvertible(stats.failed),              // entries permanently lost
+    "flushFailures": .stringConvertible(stats.flushFailures),
+    "lastFlushError": .string(stats.lastFlushErrorDescription ?? "none"),
+  ]
+)
+```
+
+If you dump them *after* `shutdown()`, that line reaches the console only — the handler discards
+records once the batcher has stopped, and counts them in `dropped`.
+
+How to read them:
+
+| Signal | Means | Do |
+|---|---|---|
+| `dropped > 0` | The hand-off buffer was full (the buffer keeps the **oldest** records, so a drop discards the newest), or the record was logged after `shutdown()` | Raise `bufferCapacity`, or ignore if it is only the tail of a clean exit |
+| `flushFailures > 0`, `failed == 0` | Flushes are failing but recovering — a failed batch goes back to the head of the buffer and a later flush retries it | Read `lastFlushErrorDescription`; the records are not lost yet |
+| `failed > 0` | Entries permanently lost: the re-buffered backlog outgrew `bufferCapacity` (oldest dropped), or `shutdown()`'s final flush failed with nothing left to retry it | Fix the underlying error; consider a larger `bufferCapacity` or a longer grace period |
+| `submitted` climbing | Working. Note it counts **entries**, so a long split record adds several | — |
+
+A failed batch is not discarded, which matters more than it sounds: the service applies **no
+clock-skew rejection at all**, so entries as old as the log's retention window land and index at
+their claimed time (anything older returns HTTP 200 and is dropped). Records buffered across an
+outage therefore survive for days. The drop policy is capacity-driven, never staleness-driven —
+the opposite of the metrics backend, which has a hard two-hour budget.
+
+`lastFlushErrorDescription` holds the raw error description, service response body included.
+Reduce it to the error's case name before serving it on an unauthenticated endpoint.
+
+---
+
+## 6. Confirm delivery against the service
+
+Counters tell you the service accepted the request. To confirm the entries are actually
+queryable, read them back with the OCI CLI. Your **own** user needs `read log-content` in that
+compartment — a separate grant from the workload's `use log-content`.
+
+```bash
+oci logging-search search-logs \
+  --search-query 'search "<compartment-ocid>/<log-group-ocid>/<log-ocid>" | sort by datetime desc' \
+  --time-start 2026-07-22T00:00:00Z \
+  --time-end   2026-07-22T01:00:00Z \
+  --limit 20
+```
+
+Allow a little time before concluding anything: end-to-end latency at the default 5-second
+`flushInterval` was measured in single-digit seconds during live verification, but Search
+indexing adds its own lag — give it a minute before deciding a record is missing.
+
+A useful triage order when nothing shows up:
+
+1. **`statistics.submitted == 0` and `flushFailures > 0`** → the request is failing.
+   `lastFlushErrorDescription` names the reason — and note that a wrong log OCID and a missing
+   `use log-content` policy both typically surface as the same `404 NotAuthorizedOrNotFound`.
+2. **`submitted > 0` but the search is empty** → you are querying the wrong log, the wrong
+   compartment, or a window that does not contain the entry's `time` (which is when the record
+   was *logged*, not when it was flushed).
+3. **Nothing at all in `statistics`** → the handler is not in the bootstrapped chain: check that
+   `LoggingSystem.bootstrap` ran before the `Logger` was created, and that the label is not in
+   `excludedLoggerLabels`.
+
+For a probe with none of the batching machinery in the way, call `PutLogs` directly — that is
+what `Tests/Services/LoggingIngestionLiveTest.swift` does:
+
+```swift
+import Foundation   // Date()
+import OCIKit
+
+let client = try LoggingIngestClient(region: .phx, signer: signer)
+try await client.putLogs(
+  logId: "ocid1.log.oc1.phx.EXAMPLE",
+  details: PutLogsDetails(
+    logEntryBatches: [
+      LogEntryBatch(
+        entries: [LogEntry(data: "hello from Swift")],
+        source: "my-host",
+        type: "com.example.orders",
+        defaultlogentrytime: Date()
+      )
+    ]
+  )
+)
+```
+
+`putLogs` returns nothing — the service answers HTTP 200 with an empty body — and **does**
+throw, unlike the batched path: `LoggingIngestionError.unexpectedStatusCode(_:_:)` carries the
+service's own code and message. That is exactly why it makes a better probe.
+
+---
+
+## Notes
+
+- **Region vs. endpoint.** `region: .phx` resolves to
+  `https://ingestion.logging.us-phoenix-1.oci.oraclecloud.com` (API version `20200831`). Pass
+  `endpoint:` instead to override; it takes precedence over `region:`.
+- **`httpClient:`** defaults to `HTTPClient.live`. Whenever `requestTimeout` is positive the
+  batcher wraps whatever you pass so every request carries it as `timeoutInterval` —
+  cancellation is not a usable bound here, because the Linux `URLSession` async shim does not
+  cancel its underlying task.
+- **Structured logs.** When a record's `data` is JSON, the service indexes it as a structured
+  log: at most 10,000 fields, names ≤ 128 bytes, values ≤ 10,000 bytes. The default renderer
+  emits text, so this only applies if you render JSON yourself.
+- **What this backend is not.** There is no Logging *Search* client and no Log Analytics client
+  in OCIKit — reading logs back is the CLI/Console path above. `PutLogs` is the whole ingestion
+  surface, and OCI Logging has no OTLP endpoint, so an OTLP logs exporter cannot target it.

--- a/docs/metrics-backend.md
+++ b/docs/metrics-backend.md
@@ -1,0 +1,426 @@
+# Metrics backend: swift-metrics → OCI Monitoring
+
+`OCIMetricsFactory` is a [swift-metrics](https://github.com/apple/swift-metrics) backend that
+publishes an application's instruments to
+[OCI Monitoring](https://docs.oracle.com/en-us/iaas/Content/Monitoring/Tasks/publishingcustommetrics.htm)
+as custom metrics. `Counter`, `Gauge`, `Recorder` and `Timer` are aggregated in process and
+posted with `PostMetricData` on a 60-second step; from there they are queryable, chartable and
+alarmable next to the platform's own `oci_*` metrics.
+
+Reach for it whenever you want application-level numbers — request rates, queue depths, handler
+latencies — in the same place as your infrastructure metrics. **Application metrics are
+self-export-only on every OCI runtime**: no agent, on any shape, collects them for you, so this
+(or an OTLP exporter pointed at APM) is the only path.
+
+- Per-runtime signer choice and copy-paste IAM policies:
+  [`observability-deployment.md`](observability-deployment.md) §2–§3.
+- The logs half of the same story: [`logging-backend.md`](logging-backend.md).
+- Wire-level research behind every limit quoted here: [`../OBSERVABILITY.md`](../OBSERVABILITY.md) §2.2.
+- Source of truth: [`../Sources/OCIKit/services/Monitoring/`](../Sources/OCIKit/services/Monitoring/).
+- A deeper, task-oriented version of this guide, packaged for an AI coding agent working in
+  this repo: [`.claude/skills/oci-metrics-backend`](../.claude/skills/oci-metrics-backend/SKILL.md).
+
+All OCIDs below are placeholders — replace the bracketed/`EXAMPLE` values with your own.
+
+---
+
+## 1. Prerequisites
+
+| You need | Why | What happens without it |
+|---|---|---|
+| A **compartment OCID** | Metric data is billed and queried per compartment; the service requires one on every metric object | `OCIMetricsConfiguration.init` throws `.missingCompartmentId` at start-up |
+| A **namespace** matching `^[a-z][a-z0-9_]*[a-z0-9]$` | The service accepts lower case only, ≤ 256 characters, no `oci_`/`oracle_` prefix | `OCIMetricsConfiguration.init` throws `.invalidNamespace` at start-up |
+| IAM `METRIC_WRITE` | `Allow dynamic-group <dg> to use metrics in compartment <compartment> where target.metrics.namespace='my_app'` | Every post fails **silently** — a `401`/`403` absorbed into a counter and a log line |
+| A **signer** | Ingestion is standard OCI request signing; every OCIKit signer works | `MonitoringClient.init` throws only for a missing region/endpoint |
+
+There is **no** log-group-equivalent to create: the namespace comes into existence with the
+first accepted post. `swift_oke` and `my_app` are legal; `swift-oke` (hyphen), `MyApp`
+(upper case) and `my_app_` (trailing underscore) are not — the last two were each live-verified
+rejected with that exact pattern quoted back in the message. A policy edit can take ~15 minutes
+to take effect on a runtime that caches its principal's token, such as Functions.
+
+**swift-metrics in your own package.** OCIKit builds against the `CoreMetrics` product, so
+`import CoreMetrics` gives you `MetricsSystem`, `Counter`, `Gauge`, `Recorder` and `Timer`
+without adding anything. The `Metrics` façade — `Timer.measure`, `Timer.record(duration:)` —
+lives in a separate module, so `import Metrics` fails unless *your* package declares it:
+
+```swift
+.package(url: "https://github.com/apple/swift-metrics.git", from: "2.11.0"),
+// …and on your target:
+.product(name: "Metrics", package: "swift-metrics"),
+```
+
+---
+
+## 2. Bootstrap
+
+```swift
+import CoreMetrics
+import Logging      // for the `Logger` handed to the factory
+import OCIKit
+
+let signer = try InstancePrincipalSigner()   // or any other signer — see the deployment guide
+let client = try MonitoringClient(region: .phx, signer: signer)
+
+let factory = OCIMetricsFactory(
+  client: client,
+  configuration: try OCIMetricsConfiguration(
+    namespace: "my_app",                     // validated eagerly — throws here, not at flush time
+    compartmentId: compartmentId,
+    commonDimensions: ["service": "checkout", "env": "prod"]
+  ),
+  logger: Logger(label: "my_app.metrics")    // default: Logger(label: "OCIMetricsFactory")
+)
+
+await factory.start()                        // start the step loop
+MetricsSystem.bootstrap(factory)             // exactly once per process — a second call traps
+
+Counter(label: "http_requests_total", dimensions: [("route", "/orders/{id}")]).increment()
+
+// before the process exits, so the last step is not lost:
+await factory.shutdown()
+```
+
+`OCIMetricsFactory.init` does not throw; `OCIMetricsConfiguration.init` does, and eagerly, so a
+process the service is going to reject fails at start-up rather than 60 seconds later on a
+background task nobody is watching. Catch it and degrade to no metrics rather than failing to
+start:
+
+```swift
+func makeMetricsFactory(signer: some Signer, compartmentId: String) async -> OCIMetricsFactory? {
+  do {
+    let factory = OCIMetricsFactory(
+      client: try MonitoringClient(region: .phx, signer: signer),
+      configuration: try OCIMetricsConfiguration(namespace: "my_app", compartmentId: compartmentId)
+    )
+    await factory.start()
+    MetricsSystem.bootstrap(factory)
+    return factory
+  }
+  catch {
+    logger.error("metrics disabled: \(error)")   // .invalidNamespace / .missingCompartmentId / …
+    return nil
+  }
+}
+```
+
+Ordering matters twice:
+
+- **`start()` before `MetricsSystem.bootstrap`**, and both before anything records —
+  swift-metrics latches its factory for the life of the process.
+- **After `LoggingSystem.bootstrap`**, so the factory's logger writes through the finished
+  logging system. Unlike the log backend, the exporter has *no* recursion guard: its warnings
+  ship to OCI Logging like any other line, which is why it gets its own label.
+
+The SDK never calls `MetricsSystem.bootstrap` itself — the process-global system belongs to the
+application, which is free to multiplex this backend with another.
+
+---
+
+## 3. What each instrument becomes
+
+One metric object per **stream** per step, where a stream is `kind + label + dimensions`.
+
+| Instrument | Posted per step |
+|---|---|
+| `Counter` | One data point: the **delta** accumulated since the previous step. An untouched step posts nothing |
+| `FloatingPointCounter` | As `Counter` — swift-metrics accumulates the fraction and forwards whole increments |
+| `Recorder` | One data point per distinct value observed, carrying its occurrence `count` |
+| `Gauge` | One data point: the most recent value, repeated every step until it changes |
+| `Meter` | As `Recorder` — swift-metrics' default meter wrapper records into an aggregating recorder, so an untouched step posts nothing |
+| `Timer` | As `Recorder`, in **nanoseconds**, with `metadata` `["unit": "ns"]` |
+
+Only `makeCounter`, `makeRecorder` and `makeTimer` are implemented; `Meter` and
+`FloatingPointCounter` are served by swift-metrics' protocol-provided wrappers, which is why
+they inherit the aggregation of the instrument they wrap. Destroying an instrument keeps the
+values it recorded since the last step, so its final partial step is still published.
+
+Internalize the delta model: **cumulative totals come from the query**
+(`http_requests_total[1m].sum()` over your window), not from the counter — which is also what
+makes them survive a restart.
+
+```swift
+let dims = [
+  ("route", route),                        // the route TEMPLATE, never the raw path
+  ("method", method),                      // allow-listed
+  ("status_class", "\(status / 100)xx"),   // the class, never the exact code
+]
+Counter(label: "http_requests_total", dimensions: dims).increment()
+```
+
+**Cardinality is your job.** Every distinct combination of dimension values mints its own
+stream, and streams cost requests, money and query legibility. Never dimension by raw path,
+object name, user id, or anything else caller-controlled. Idle streams cost nothing — an alarm
+reads the gap as "no data".
+
+### What gets coerced for you
+
+swift-metrics constrains labels and dimensions not at all; `PostMetricData` does. Rather than
+throw the application's data away, the backend coerces it:
+
+- **Metric names** are forced to `^[a-zA-Z][a-zA-Z0-9_.$-]*[a-zA-Z0-9]$`, ≤ 255 characters:
+  illegal characters become `_`, leading characters are dropped until it starts with a letter,
+  trailing ones until it ends with a letter or digit. So `Counter(label: "login attempts")`
+  posts as `login_attempts`, and `Timer(label: "http/server/duration")` as
+  `http_server_duration`. A label with nothing salvageable posts as `unnamed_metric`.
+- **Dimension keys** collapse runs of whitespace to `_` and truncate at 256 characters;
+  **values** are trimmed and truncated at 512. An entry that ends up with an empty key or value
+  is dropped.
+- **A default dimension is synthesized** when a metric would otherwise have none — the service
+  rejects an empty map with `400 "dimensions can not be null or empty"`, and swift-metrics
+  instruments are routinely created with no dimensions at all. Default key `source`, default
+  value the host name.
+- **Dimensions are capped at 20**, the service limit, keeping the lexicographically-first keys
+  so the choice is deterministic across steps and processes.
+- **`NaN` and `±Infinity` are refused at the recording boundary** — they have no JSON
+  representation — and counted in `droppedSamples`.
+
+The two rules coercion cannot rescue are yours: the namespace (§1) and the 20-dimension cap.
+
+---
+
+## 4. The configuration surface
+
+| Parameter | Default | Change it when |
+|---|---|---|
+| `namespace` | *(required)* | — |
+| `compartmentId` | *(required)* | — |
+| `resourceGroup` | `nil` | You group metrics by resource group in the Console |
+| `commonDimensions` | `[:]` | Always worth setting: service, environment, instance. Sanitized once, here, and merged **over** an instrument's own dimensions on a key collision — operator labels application code cannot shadow |
+| `defaultDimensionName` | `"source"` (`OCIMetricsConfiguration.fallbackDimensionName`) | Another key reads better for label-less metrics |
+| `defaultDimensionValue` | `ProcessInfo.processInfo.hostName` | **On OKE virtual nodes the host name is `localhost` for every pod** — take the pod name from the downward API instead. Falls back to `"unknown"` if unusable |
+| `step` | `.seconds(60)` | Rarely. 60 s is Monitoring's minimum aggregation interval and matches Oracle's own Micronaut/Helidon integrations; shortening it spends the tenancy's 50 TPS `PostMetricData` budget and buys nothing |
+| `maximumBufferedStreams` | `500` | `droppedBufferedStreams` is climbing during outages. **This bounds the retry buffer only** — a step's fresh streams are always posted, however many there are |
+| `maximumSamplesPerStream` | `1000` | `droppedSamples` is climbing: a recorder or timer sees more than 1,000 distinct values per step. Repeats of an already-seen value always count; only new distinct values are dropped |
+
+```swift
+try OCIMetricsConfiguration(
+  namespace: "my_app",
+  compartmentId: compartmentId,
+  resourceGroup: nil,
+  commonDimensions: ["service": "checkout", "env": "prod"],
+  defaultDimensionName: OCIMetricsConfiguration.fallbackDimensionName,   // "source"
+  defaultDimensionValue: podName,
+  step: .seconds(60),          // Swift.Duration — spelled in full because OCIKit also
+                               // exports an Object Storage lifecycle model named `Duration`
+  maximumBufferedStreams: 500,
+  maximumSamplesPerStream: 1000
+)
+```
+
+The initializer throws `OCIMetricsError` — `.invalidNamespace`, `.missingCompartmentId`,
+`.invalidStep`, `.invalidBufferBound`. Nothing is clamped; a bad value is a start-up failure.
+
+### What a flush does
+
+Worth knowing when reading the counters in §6:
+
+1. Drain the registry; turn each stream into a `MetricDataDetails` timestamped at the instant of
+   the snapshot.
+2. Prepend anything the previous flush could not deliver. That carried-over set — and only it —
+   is what `maximumBufferedStreams` bounds, applied as the buffer is written back at the end of
+   the flush; a step's fresh streams are never dropped for being numerous.
+3. Drop data points older than the service's **two-hour** window — it refuses them, so carrying
+   them further would poison every retry.
+4. Split into requests of at most **50 streams** (a 51st fails the whole request with
+   `400 "The valid range is 1 to 50"`) and post them.
+5. Read `failedMetrics` out of each `200`, and buffer for retry only the chunks that failed
+   *transiently*.
+
+Step 5 is the subtle one. **Partial failures arrive inside a `200`**: under the service's
+default non-atomic batching the valid metric objects are ingested and the rejected ones come
+back in the response body. Those rejections are permanent — the metric object violated an input
+rule — so they are counted, logged, and dropped rather than retried. A thrown error is
+classified the same way: a client-side encoding failure and any `4xx` other than `408`/`429`
+are permanent (re-posting an identical payload would be rejected identically forever, burning
+the tenancy's TPS budget); everything else goes back into the retry buffer.
+
+---
+
+## 5. Shut down without losing the step
+
+`shutdown()` cancels the step task, **awaits** it, and then flushes, so no request is in flight
+once it returns. Skipping it loses up to a full step — and the step task retains the factory, so
+dropping the last reference does not stop it.
+
+```swift
+await factory.flush()      // mid-life: snapshot and publish now, without disturbing the cadence
+await factory.shutdown()   // cancel the step task, await it, publish what is left
+```
+
+Drive it from your service lifecycle, exactly as with the log backend
+([`logging-backend.md`](logging-backend.md) §4) —
+[swift-service-lifecycle](https://github.com/swift-server/swift-service-lifecycle) 2.x is a
+dependency of *your* package:
+
+```swift
+import ServiceLifecycle
+
+// Spell `Service` in full — `import OCIKit` also brings one in (the OCI service catalogue).
+struct MetricsFlushService: ServiceLifecycle.Service {
+  let factory: OCIMetricsFactory
+
+  func run() async throws {
+    try await gracefulShutdown()   // parks until SIGTERM
+    await factory.shutdown()
+  }
+}
+
+// A `ServiceGroup` tears down in REVERSE array order — the flush service goes FIRST so it
+// drains LAST. Listed after the server, it would flush mid-drain and lose everything after.
+let group = ServiceGroup(
+  services: [metricsFlush, server],
+  gracefulShutdownSignals: [.sigterm],
+  logger: logger
+)
+```
+
+**Budget the grace period.** Unlike `OCILogBatcher`, `MonitoringClient` has no built-in request
+timeout: it defaults to `HTTPClient.live`, so an unanswered `PostMetricData` inherits
+`URLSession`'s 60-second default, and `shutdown()` can perform more than one request. If the
+runtime enforces a termination grace period, bound the transport yourself — Linux's async
+`URLSession` shim ignores cancellation, so this is the only bound that binds:
+
+```swift
+let client = try MonitoringClient(
+  region: .phx,
+  signer: signer,
+  httpClient: HTTPClient { request in
+    var request = request
+    request.timeoutInterval = 5
+    return try await HTTPClient.live.data(request)
+  }
+)
+```
+
+---
+
+## 6. Failures are never thrown — `statistics()` is the only counter
+
+> **Nothing on the export path throws.** A metrics backend that can take its application down is
+> worse than one that loses a step, so every loss is absorbed and counted instead. A missing
+> `use metrics` policy, a malformed dimension, a two-hour outage — none of them surfaces as an
+> error to your code.
+
+Unlike the log backend, the exporter is not *silent*: it has no recursion to guard against, so
+it reports through the logger you handed it. Read the app's own logs first:
+
+| Log line | Meaning |
+|---|---|
+| `[OCIMetricsExporter] postMetricData permanently rejected N stream(s), dropping them: …` | A `4xx` outside `408`/`429`, or an encoding failure. A missing `use metrics` policy surfaces here as the `401`/`403` text |
+| `[OCIMetricsExporter] postMetricData failed for N stream(s), will retry: …` | Transient — buffered for the next step |
+| `[OCIMetricsExporter] metric "x" rejected: <service message>` | One record refused **inside a `200`**; permanent, never retried |
+| `[OCIMetricsExporter] dropped N datapoint(s) older than the service's 2-hour window` | The outage budget is spent |
+| `[OCIMetricsExporter] dropped N buffered metric stream(s): the retry buffer is full` | `maximumBufferedStreams` reached |
+| `[postMetricData] <code> (<status>): <message>` | From `MonitoringClient` itself, on any non-`200` |
+
+`await factory.statistics()` is the only *counter*. All seven are `Int`, monotonic for the life
+of the factory, and never reset — surface them where an operator reads them:
+
+| Counter | Means |
+|---|---|
+| `postedStreams` | Metric streams the service accepted |
+| `postedDatapoints` | Data points the service accepted |
+| `failedMetrics` | Streams rejected permanently — inside a `200`, or by a permanently-failed request |
+| `failedRequests` | Requests that failed outright: transport error, throttling, non-`200` |
+| `droppedStaleDatapoints` | Data points that aged past the two-hour window |
+| `droppedBufferedStreams` | Streams dropped because the retry buffer was full |
+| `droppedSamples` | Observations dropped at the per-step distinct-value bound, or for being non-finite |
+
+The asymmetry with logs is worth remembering: **metrics have a hard two-hour outage budget**
+(`(now − 2h, now + 10m)`, strictly enforced and live-verified), where buffered log entries
+survive for days. If `droppedStaleDatapoints` is non-zero, the outage outlasted what the service
+will accept and that data is permanently unpostable.
+
+---
+
+## 7. Confirm delivery against the service
+
+Counters tell you the service accepted the request. To confirm the metrics are queryable, ask
+Monitoring. Allow 1–2 minutes after the first step. Your **own** user needs `read metrics` in
+that compartment — a separate grant from the workload's `use metrics`.
+
+```bash
+# Which streams exist, and their dimension keys — the fastest cardinality check.
+oci monitoring metric list \
+  --compartment-id <compartment-ocid> \
+  --namespace my_app \
+  --all
+
+# Read the datapoints back with an MQL query.
+oci monitoring metric-data summarize-metrics-data \
+  --compartment-id <compartment-ocid> \
+  --namespace my_app \
+  --query-text 'http_requests_total[1m].sum()' \
+  --start-time 2026-07-22T00:00:00Z \
+  --end-time   2026-07-22T01:00:00Z
+```
+
+The CLI is the read-back path because OCIKit ships **no query client**: `ListMetrics` and
+`SummarizeMetricsData` live on a different host (`telemetry.{region}.oraclecloud.com`, versus
+the ingestion host `telemetry-ingestion.{region}.oraclecloud.com`) and are deliberately out of
+scope. The Console's Metrics Explorer works just as well.
+
+A useful triage order when nothing shows up:
+
+1. **`failedRequests > 0`** → read the exporter's log lines above. `401`/`403` means the policy;
+   `400` usually means a request-level rule (more than 50 streams, or every metric object
+   invalid).
+2. **`failedMetrics > 0` with `failedRequests == 0`** → the service is rejecting individual
+   metric objects inside a `200`. The `metric "x" rejected: …` line carries the service's own
+   explanation.
+3. **`postedStreams > 0` but `metric list` is empty** → wrong compartment or wrong namespace on
+   the query side. The namespace has to match the configured one exactly.
+4. **Everything zero** → the step has not fired yet (it is 60 seconds), or `start()` was never
+   called, or `MetricsSystem.bootstrap` ran after the instruments were created.
+
+For a probe with none of the aggregation machinery in the way, post directly:
+
+```swift
+import Foundation   // Date()
+import OCIKit
+
+let client = try MonitoringClient(region: .phx, signer: signer)
+let response = try await client.postMetricData(
+  details: PostMetricDataDetails(
+    metricData: [
+      MetricDataDetails(
+        namespace: "my_app",
+        compartmentId: compartmentId,
+        name: "requests",
+        dimensions: ["host": "worker-1"],
+        metadata: ["unit": "count"],
+        datapoints: [MonitoringDatapoint(timestamp: Date(), value: 42)]
+      )
+    ]
+  )
+)
+if response.failedMetricsCount > 0 {
+  logger.warning("\(response.failedMetricsCount) metric(s) rejected: \(response.failedMetrics ?? [])")
+}
+```
+
+`MonitoringClient` is a faithful transport for one request — it does **not** chunk, sanitize, or
+drop anything on your behalf, so a direct caller owns every limit in §3 and §4. It throws
+`MonitoringError.unexpectedStatusCode(_:_:)` on a non-`200`, which is exactly what makes it a
+better probe than the batched path. And it returns the decoded body rather than discarding it,
+because checking only for a thrown error silently loses the partial failures.
+
+---
+
+## Notes
+
+- **Region vs. endpoint.** `region: .phx` resolves to
+  `https://telemetry-ingestion.us-phoenix-1.oraclecloud.com` (API version `20180401`) — note
+  there is no `.oci.` segment, and it is a different host from the query side. Pass `endpoint:`
+  to override; it takes precedence over `region:`.
+- **`retryConfig:`** on `MonitoringClient` defaults to `nil` (no retries). The exporter's own
+  step-to-step retry buffer covers transient failures, so adding client-level retries mostly
+  lengthens `shutdown()`.
+- **Cost.** The first 500 M data points per month are free, then $0.0025 per million —
+  effectively free for anything this backend produces. Cardinality costs you query legibility
+  long before it costs money.
+- **Not a substitute.** OTLP metrics sent to an APM domain surface in Monitoring under the
+  `oracle_apm_monitoring` namespace, but that path needs an APM domain plus its private data key
+  and cannot use OCI principals. For traces — which OCI *does* ingest over OTLP — see
+  [`../Examples/apm-tracing/README.md`](../Examples/apm-tracing/README.md).

--- a/docs/observability-deployment.md
+++ b/docs/observability-deployment.md
@@ -316,7 +316,8 @@ await batcher.shutdown()
 ```
 
 Full behavior — batching, truncation-splitting, the recursion guard, and what counts as a
-dropped vs. a retried record — is documented in the [README](../README.md#logging-backend).
+dropped vs. a retried record — is documented in [`logging-backend.md`](logging-backend.md)
+§3–§5.
 
 ### 5.2 Metrics — `OCIMetricsFactory`
 
@@ -341,7 +342,7 @@ await factory.shutdown()
 ```
 
 Full behavior — 50-stream chunking, dimension sanitization, the two-hour staleness drop — is
-documented in the [README](../README.md#metrics-backend).
+documented in [`metrics-backend.md`](metrics-backend.md) §3–§4.
 
 ### 5.3 Traces — swift-otel → APM
 


### PR DESCRIPTION
Documentation only — no Swift source, test, manifest or workflow changes. Follow-up to the
observability epic merged in #94.

## ROADMAP — what is now recorded as done

The observability work is marked shipped in every place the file references it, so no entry
still reads as future work:

- **Tier 1 #1 (Logging Ingestion + swift-log backend)** — `**Status: shipped 2026-07**`,
  live-verified against a real tenancy and a real OKE cluster. The entry now also records that
  the deliverable expanded: the promoted Monitoring `postMetricData` slice + `OCIMetricsFactory`,
  the approved `swift-metrics` core dependency, the `OCIKitFunctions` tracing-context work (#86),
  and the fact that tracing needed no client at all (APM ingests OTLP with data-key auth, so the
  deliverable was a documented recipe).
- **Audit summary table** — `Tier 1 — high priority | 3 (1 shipped 2026-07)` and
  `Backlog — low priority | 16 (1 partially shipped 2026-07)`. The backlog annotation is there
  because Monitoring's `postMetricData` half shipped while the entry stays in the backlog for
  its unshipped half.
- **"Already implemented"** — gains Logging Ingestion (`putLogs` + `OCILogHandler`) and
  Monitoring (ingestion only — `postMetricData` + `OCIMetricsFactory`).
- **Backlog → Observability** — the Monitoring entry keeps its place, now stating which half
  shipped and which did not.
- **Suggested sequencing** — phase 2 marked shipped, with Email Data Plane named as the
  remainder of that phase.
- **Cross-cutting note 2** — records the two `Region+Service` cases added in 2026-07
  (`ingestion.logging.*`, `telemetry-ingestion.*`).

## What is deliberately still NOT marked done

- `summarizeMetricsData` / `listMetrics` and the `telemetry.*` query host — explicitly out of
  scope, still backlog, demand-gated.
- **Logging Search** (`loggingsearch`) and **Log Analytics** (`log_analytics`) — unchanged by
  this work, still backlog.
- **#87**, the swift-log 1.14 / `LogEvent` follow-up — still open, and named as such in the
  Tier 1 entry.
- **APM trace query** — remains in the excluded list; only trace *ingest* shipped, as a recipe.

## Two extracted docs

The README's `Logging backend` and `Metrics backend` sections moved into their own guides and
were expanded where the README had to be terse, matching the voice and structure of the existing
`docs/observability-deployment.md`:

- **[`docs/logging-backend.md`](docs/logging-backend.md)** — prerequisites (and the fact that
  none of them is checked at runtime), the bootstrap composition, the full
  `OCILogHandlerConfiguration` surface, the three-part recursion guard, flush/shutdown wiring via
  swift-service-lifecycle, how to read `statistics`, and how to confirm delivery with
  `oci logging-search` plus a direct `putLogs` probe.
- **[`docs/metrics-backend.md`](docs/metrics-backend.md)** — prerequisites and namespace rules,
  bootstrap and start/shutdown ordering, what each instrument becomes on the wire, what the
  backend coerces for you, the configuration surface, what a flush actually does (50-stream
  chunking, the two-hour window, partial failures inside a `200`), the seven counters, and
  verification via `oci monitoring` plus a direct `postMetricData` probe.

Every snippet in both docs was checked against the merged source in `Sources/OCIKit/` rather
than trusted from the README's old text, and each standalone probe snippet carries its own
import header.

## README

- Both moved sections replaced with a couple of sentences — what it is, why you would reach for
  it — and a link to the new guide.
- TODO list gains `- [x] Monitoring (PostMetricData) + a swift-metrics backend`, phrased to
  match the existing Logging Ingestion line.
- New **Skills** section explaining what an agent skill is in this repo (packaged instructions an
  AI coding agent loads on demand, so recurring jobs follow this project's conventions), then
  indexing all five skills in `.claude/skills/` with a line each on what it does and when it
  fires: `oci-new-service-client`, `oci-capture-fixtures`, `oci-wire-tests`,
  `oci-logging-backend`, `oci-metrics-backend`.

## One cross-reference fix outside the four files

`docs/observability-deployment.md` §5.1 and §5.2 each sent the reader to a README anchor for the
backends' full behavior — batching, the recursion guard, 50-stream chunking, dimension
sanitization, the two-hour staleness drop. Those anchors still resolve, but the material behind
them moved into the new guides, so the pointers are repointed at `logging-backend.md` §3–§5 and
`metrics-backend.md` §3–§4. Two lines; these were the only `README.md#` links in the repo.

## Verification

- All 37 relative links across the changed and new docs resolve to files that exist.
- No real OCIDs, tenancy ids, or data keys — the only OCID in the diff is
  `ocid1.log.oc1.phx.EXAMPLE`; the only hosts are public regional service endpoints and
  `docs.oracle.com`.
- Nothing under `Sources/`, `Tests/`, `Package.swift`, or `.github/`.

Refs #85
