### PR TITLE
Fix getObject(range:) dropping the byte range and rejecting 206 (#96)

### DIFF
--- a/.claude/skills/oci-capture-fixtures/SKILL.md
+++ b/.claude/skills/oci-capture-fixtures/SKILL.md
@@ -106,6 +106,10 @@ Open the captured JSON and scrub anything real:
 
 - OCIDs (tenancy, compartment, user, resource) → replace the unique suffix with
   `EXAMPLE`, e.g. `ocid1.compartment.oc1..EXAMPLE`
+- The real tenancy Object Storage **namespace** (it appears in every object
+  `request.url` and in some bodies) → replace with a placeholder namespace. Reuse
+  the same placeholder the existing committed fixtures already use, so tests stay
+  consistent — never leave the live tenancy namespace in a fixture.
 - Tenancy/company names, email addresses, real resource names
 - `opc-request-id` and any other request-id-shaped header → `EXAMPLE`
 - Pre-Authenticated Request (PAR) tokens, SAS-like tokens, or any secret body
@@ -158,6 +162,13 @@ let fixture = try HTTPFixture.load(fromFile: URL(filePath: "Tests/Services/Fixtu
   developer with a configured `~/.oci/config` profile. It must never be added to
   `.github/workflows/linux.yml`'s `UNIT_TEST_FILTER` — that list is for
   credential-free hermetic/replay suites only.
+- **Never hardcode the config profile name or the real tenancy Object Storage
+  namespace in the capture test (or any source/comment).** Both are
+  tenancy-specific identifiers that read as leaked internal references. Drive them
+  through env vars (`OCI_PROFILE`, `OCI_NAMESPACE`, ...) as the examples above do,
+  and scrub the namespace out of the committed fixture (see step 4). In test code
+  and comments, refer to "live OCI" / "see `OCICaptureTests`" rather than naming
+  the profile.
 - Once the fixture is committed, hand off to **oci-wire-tests** to write the
   hermetic replay suite (`Tests/Services/<Service>HermeticTests.swift`) that
   loads it via `HTTPClient.replaying(fromFile:)` and asserts on request shape

--- a/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
+++ b/Sources/OCIKit/services/ObjectStorage/ObjectStorage.swift
@@ -829,7 +829,9 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
     }
 
-    if httpResponse.statusCode != 200 {
+    // 200 = whole object; 206 = Partial Content, returned when a `range` was
+    // requested. Both carry a valid body, so accept either.
+    if httpResponse.statusCode != 200 && httpResponse.statusCode != 206 {
       let errorBody = try JSONDecoder().decode(DataBody.self, from: data)
       self.logger.error("[getObject] \(errorBody.code) (\(httpResponse.statusCode)): \(errorBody.message)")
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)
@@ -922,7 +924,9 @@ public struct ObjectStorageClient: Sendable {
       throw ObjectStorageError.invalidResponse("Invalid HTTP response")
     }
 
-    if httpResponse.statusCode != 200 {
+    // 200 = whole object; 206 = Partial Content, returned when a `range` was
+    // requested. Both carry a valid body, so accept either.
+    if httpResponse.statusCode != 200 && httpResponse.statusCode != 206 {
       let errorBody = try JSONDecoder().decode(DataBody.self, from: data)
       self.logger.error("[getObjectPAR] \(errorBody.code) (\(httpResponse.statusCode)): \(errorBody.message)")
       throw ObjectStorageError.unexpectedStatusCode(httpResponse.statusCode, errorBody.message)

--- a/Sources/OCIKit/services/ObjectStorage/ObjectStorageRouter.swift
+++ b/Sources/OCIKit/services/ObjectStorage/ObjectStorageRouter.swift
@@ -569,8 +569,6 @@ public enum ObjectStorageAPI: API {
       .createPreauthenticatedRequest(_, _, let opcClientRequestId),
       .deletePreauthenticatedRequest(_, _, _, let opcClientRequestId),
       .getBucket(_, _, let opcClientRequestId),
-      .getObject(_, _, _, _, let opcClientRequestId, _, _, _, _, _, _, _, _, _, _),
-      .getObjectWithPAR(_, _, _, let opcClientRequestId, _, _, _, _, _, _, _, _, _, _),
       .getNamespace(_, let opcClientRequestId),
       .getNamespaceMetadata(_, let opcClientRequestId),
       .getReplicationPolicy(_, _, _, let opcClientRequestId),
@@ -578,7 +576,6 @@ public enum ObjectStorageAPI: API {
       .getPreauthenticatedRequest(_, _, _, let opcClientRequestId),
       .getWorkRequest(_, let opcClientRequestId),
       .headBucket(_, _, let opcClientRequestId),
-      .headObject(_, _, _, _, let opcClientRequestId, _, _, _),
       .listBuckets(_, _, _, _, _, let opcClientRequestId),
       .listReplicationPolicies(_, _, _, _, let opcClientRequestId),
       .listReplicationSources(_, _, _, _, let opcClientRequestId),
@@ -601,6 +598,50 @@ public enum ObjectStorageAPI: API {
         return ["opc-client-request-id": opcClientRequestId]
       }
       return nil
+
+    // GetObject (direct and PAR) carries the byte range and the optional
+    // customer-supplied (SSE-C) encryption headers in addition to the tracing
+    // id. These must reach the wire: `range` selects the byte window (server
+    // answers 206 Partial Content), and the SSE-C trio decrypts the object.
+    // Query-string overrides (versionId, httpResponse*) are handled in
+    // `queryItems`, matching the OCI GetObject spec and the Python SDK.
+    case .getObject(
+      _, _, _, _, let opcClientRequestId, let range, let opcSseCustomerAlgorithm, let opcSseCustomerKey,
+      let opcSseCustomerKeySha256, _, _, _, _, _, _
+    ),
+      .getObjectWithPAR(
+        _, _, _, let opcClientRequestId, let range, let opcSseCustomerAlgorithm, let opcSseCustomerKey,
+        let opcSseCustomerKeySha256, _, _, _, _, _, _
+      ):
+      let keyValuePairs: [(String, String)] = [
+        ("opc-client-request-id", opcClientRequestId),
+        ("range", range),
+        ("opc-sse-customer-algorithm", opcSseCustomerAlgorithm),
+        ("opc-sse-customer-key", opcSseCustomerKey),
+        ("opc-sse-customer-key-sha256", opcSseCustomerKeySha256),
+      ].compactMap { key, value in
+        value.map { (key, $0) }
+      }
+
+      let headers = Dictionary(uniqueKeysWithValues: keyValuePairs)
+      return headers.isEmpty ? nil : headers
+
+    // HeadObject has no byte range but shares the SSE-C headers so an encrypted
+    // object's metadata can be fetched with the customer key.
+    case .headObject(
+      _, _, _, _, let opcClientRequestId, let opcSseCustomerAlgorithm, let opcSseCustomerKey, let opcSseCustomerKeySha256
+    ):
+      let keyValuePairs: [(String, String)] = [
+        ("opc-client-request-id", opcClientRequestId),
+        ("opc-sse-customer-algorithm", opcSseCustomerAlgorithm),
+        ("opc-sse-customer-key", opcSseCustomerKey),
+        ("opc-sse-customer-key-sha256", opcSseCustomerKeySha256),
+      ].compactMap { key, value in
+        value.map { (key, $0) }
+      }
+
+      let headers = Dictionary(uniqueKeysWithValues: keyValuePairs)
+      return headers.isEmpty ? nil : headers
 
     case .putObject(_, _, _, let contentLength, let contentMD5, let opcClientRequestId, let storageTier):
       let keyValuePairs: [(String, String)] = [

--- a/Tests/Services/Fixtures/getObjectRange.json
+++ b/Tests/Services/Fixtures/getObjectRange.json
@@ -1,0 +1,27 @@
+{
+  "bodyBase64": "MDEyMzQ1Njc4OTAxMjM0NQ==",
+  "headers": {
+    "Accept-Ranges": "bytes",
+    "Access-Control-Allow-Origin": "*",
+    "Content-Length": "16",
+    "Content-Type": "application/octet-stream",
+    "Date": "Thu, 23 Jul 2026 18:49:32 GMT",
+    "Etag": "EXAMPLEETAG0000-0000-0000-000000000000",
+    "Last-Modified": "Thu, 23 Jul 2026 18:48:50 GMT",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+    "access-control-allow-credentials": "true",
+    "access-control-allow-methods": "POST,PUT,GET,HEAD,DELETE,OPTIONS",
+    "access-control-expose-headers": "accept-ranges,access-control-allow-credentials,access-control-allow-methods,access-control-allow-origin,content-length,content-range,content-type,date,etag,last-modified,opc-client-info,opc-request-id,storage-tier,strict-transport-security,version-id,x-api-id,x-content-type-options",
+    "content-range": "bytes 0-15/1024",
+    "opc-request-id": "phx-1/CAPTURE00000EXAMPLE/BLOCK00000EXAMPLE",
+    "storage-tier": "Standard",
+    "version-id": "EXAMPLE-VERSION-ID",
+    "x-api-id": "native",
+    "x-content-type-options": "nosniff"
+  },
+  "request": {
+    "method": "GET",
+    "url": "https://objectstorage.us-phoenix-1.oraclecloud.com/n/frjfldcyl3la/b/oci-swift-sdk-range-test/o/range-object.txt"
+  },
+  "statusCode": 206
+}

--- a/Tests/Services/OCICaptureTests.swift
+++ b/Tests/Services/OCICaptureTests.swift
@@ -68,6 +68,50 @@ struct OCICaptureTests {
     logger.info("OCICaptureTests: captured getNamespace -> \"\(namespace)\"; fixture written under \(out)")
   }
 
+  /// Captures a real ranged `getObject` — the fix for issue #96. The `range`
+  /// header makes OCI answer 206 Partial Content with only the requested window,
+  /// so the committed fixture proves both the request the SDK builds and that the
+  /// client accepts a 206 body. Requires a preexisting object; create one first,
+  /// e.g. `oci os object put --bucket-name <b> --name <o> --file <f>`.
+  @Test("captures a ranged getObject (206 Partial Content) from a live endpoint into a fixture")
+  func captureGetObjectRange() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard let base = env["OCI_CAPTURE_BASE_URL"], let out = env["OCI_FIXTURE_OUT"],
+      let namespace = env["OCI_NAMESPACE"], let bucket = env["OCI_BUCKET"], let object = env["OCI_OBJECT"]
+    else {
+      logger.info(
+        "captureGetObjectRange skipped — set OCI_CAPTURE_BASE_URL, OCI_FIXTURE_OUT, OCI_NAMESPACE, OCI_BUCKET, OCI_OBJECT."
+      )
+      return
+    }
+    let range = env["OCI_RANGE"] ?? "bytes=0-15"
+
+    // Real OCI needs a real signature; a local mock endpoint does not.
+    let signer: Signer
+    if let configFile = env["OCI_CONFIG_FILE"] {
+      signer = try APIKeySigner(configFilePath: configFile, configName: env["OCI_PROFILE"] ?? "DEFAULT")
+    }
+    else {
+      signer = CaptureStubSigner()
+    }
+
+    let client = try ObjectStorageClient(
+      endpoint: base,
+      signer: signer,
+      httpClient: .recording(into: URL(filePath: out))
+    )
+
+    let data = try await client.getObject(
+      namespaceName: namespace,
+      bucketName: bucket,
+      objectName: object,
+      range: range
+    )
+    logger.info(
+      "OCICaptureTests: captured ranged getObject (\(range)) -> \(data.count) bytes; fixture written under \(out)"
+    )
+  }
+
   // MARK: - Secrets Retrieval API captures
 
   /// Builds a live, recording `SecretsClient` for the configured profile, or

--- a/Tests/Services/OCIFixtureReplayTests.swift
+++ b/Tests/Services/OCIFixtureReplayTests.swift
@@ -55,4 +55,33 @@ struct OCIFixtureReplayTests {
     // The header the client reads for tracing was captured from the wire:
     #expect(fixture.headers.keys.contains { $0.lowercased() == "opc-request-id" })
   }
+
+  // issue #96: a ranged getObject must accept the 206 Partial Content the server
+  // answers with and hand back only the requested byte window. This replays a
+  // real 206 response captured from live OCI (see OCICaptureTests) against the client.
+  @Test("getObject replays a captured 206 Partial Content response (issue #96)")
+  func replayGetObjectRange() async throws {
+    let http = try HTTPClient.replaying(fromFile: fixtureURL("getObjectRange.json"))
+    let client = try ObjectStorageClient(region: .phx, signer: ReplayStubSigner(), httpClient: http)
+
+    let data = try await client.getObject(
+      namespaceName: "frjfldcyl3la",
+      bucketName: "oci-swift-sdk-range-test",
+      objectName: "range-object.txt",
+      range: "bytes=0-15"
+    )
+
+    #expect(data.count == 16)  // the 16-byte window, not the 1024-byte object
+    #expect(String(data: data, encoding: .utf8) == "0123456789012345")
+  }
+
+  @Test("the captured 206 range fixture round-trips through HTTPFixture")
+  func rangeFixtureDecodes() throws {
+    let fixture = try HTTPFixture.load(fromFile: fixtureURL("getObjectRange.json"))
+    #expect(fixture.statusCode == 206)  // Partial Content
+    #expect(fixture.request.method == "GET")
+    #expect(fixture.body.count == 16)
+    // The server echoes the granted window; casing preserved as captured.
+    #expect(fixture.headers.contains { $0.key.lowercased() == "content-range" && $0.value == "bytes 0-15/1024" })
+  }
 }

--- a/Tests/Services/ObjectStorageHermeticTests.swift
+++ b/Tests/Services/ObjectStorageHermeticTests.swift
@@ -146,4 +146,124 @@ struct ObjectStorageHermeticTests {
       _ = try await client.getNamespace()
     }
   }
+
+  // MARK: - Ranged GetObject (issue #96)
+
+  // The core regression for #96: a ranged read must (a) put the byte window on the
+  // wire as a `Range` header and (b) accept the 206 Partial Content the server
+  // answers with. The old router bound `range` to `_` and emitted only
+  // opc-client-request-id, and the client rejected any status != 200 — so a
+  // ranged get silently over-fetched (200 + whole object) or threw on 206.
+  @Test("getObject: emits the Range header and accepts a 206 partial response")
+  func getObjectRangeHeader() async throws {
+    let recorder = RequestRecorder()
+    let partial = Data("0123".utf8)  // 4 bytes -> bytes=0-3
+    let client = try makeClient(
+      status: 206,
+      body: partial,
+      responseHeaders: ["Content-Range": "bytes 0-3/1024", "Content-Length": "4"],
+      recorder: recorder
+    )
+
+    let data = try await client.getObject(
+      namespaceName: "frjfldcyl3la",
+      bucketName: "test_bucket_by_sdk",
+      objectName: "big.bin",
+      range: "bytes=0-3"
+    )
+
+    #expect(data == partial)  // 206 accepted; only the requested window is returned
+    let req = await recorder.last
+    #expect(req?.httpMethod == "GET")
+    #expect(req?.url?.path == "/n/frjfldcyl3la/b/test_bucket_by_sdk/o/big.bin")
+    #expect(req?.value(forHTTPHeaderField: "range") == "bytes=0-3")
+  }
+
+  // Regression guard the other way: an unranged read must NOT send a Range header
+  // (else the server answers 206 for a full-object fetch).
+  @Test("getObject: omits the Range header when no range is requested")
+  func getObjectNoRangeHeader() async throws {
+    let recorder = RequestRecorder()
+    let client = try makeClient(status: 200, body: Data("full-object".utf8), recorder: recorder)
+
+    _ = try await client.getObject(
+      namespaceName: "frjfldcyl3la",
+      bucketName: "test_bucket_by_sdk",
+      objectName: "big.bin"
+    )
+
+    let req = await recorder.last
+    #expect(req?.value(forHTTPHeaderField: "range") == nil)
+  }
+
+  // The same router arm also dropped the SSE-C customer headers; they must reach
+  // the wire so customer-supplied encryption keys are actually honored.
+  @Test("getObject: emits the SSE-C customer headers when provided")
+  func getObjectSSEHeaders() async throws {
+    let recorder = RequestRecorder()
+    let client = try makeClient(status: 200, body: Data("cipher".utf8), recorder: recorder)
+
+    _ = try await client.getObject(
+      namespaceName: "frjfldcyl3la",
+      bucketName: "test_bucket_by_sdk",
+      objectName: "enc.bin",
+      opcSseCustomerAlgorithm: "AES256",
+      opcSseCustomerKey: "dGVzdC1rZXk=",
+      opcSseCustomerKeySha256: "dGVzdC1zaGE="
+    )
+
+    let req = await recorder.last
+    #expect(req?.value(forHTTPHeaderField: "opc-sse-customer-algorithm") == "AES256")
+    #expect(req?.value(forHTTPHeaderField: "opc-sse-customer-key") == "dGVzdC1rZXk=")
+    #expect(req?.value(forHTTPHeaderField: "opc-sse-customer-key-sha256") == "dGVzdC1zaGE=")
+  }
+
+  // The PAR variant shares the same buggy router arm (getObjectWithPAR) and the
+  // same 200-only status check, so it needs its own coverage.
+  @Test("getObject(parURL:): emits the Range header and accepts a 206 partial response")
+  func getObjectPARRangeHeader() async throws {
+    let recorder = RequestRecorder()
+    let partial = Data("ab".utf8)
+    let client = try makeClient(
+      status: 206,
+      body: partial,
+      responseHeaders: ["Content-Range": "bytes 0-1/100", "Content-Length": "2"],
+      recorder: recorder
+    )
+    let par = URL(
+      string:
+        "https://frjfldcyl3la.objectstorage.us-ashburn-1.oraclecloud.com/p/tokenEXAMPLE/n/frjfldcyl3la/b/test_bucket_by_sdk/o/"
+    )!
+
+    let data = try await client.getObject(parURL: par, objectName: "big.bin", range: "bytes=0-1")
+
+    #expect(data == partial)
+    let req = await recorder.last
+    #expect(req?.httpMethod == "GET")
+    #expect(req?.value(forHTTPHeaderField: "range") == "bytes=0-1")
+  }
+
+  // headObject carried the same SSE-C parameters and dropped them the same way
+  // (it has no range parameter). Assert only the request shape; the response
+  // parsing is exercised elsewhere.
+  @Test("headObject: emits the SSE-C customer headers when provided")
+  func headObjectSSEHeaders() async throws {
+    let recorder = RequestRecorder()
+    let client = try makeClient(status: 200, body: Data(), recorder: recorder)
+
+    _ = try? await client.headObject(
+      namespaceName: "frjfldcyl3la",
+      bucketName: "test_bucket_by_sdk",
+      objectName: "enc.bin",
+      opcSseCustomerAlgorithm: "AES256",
+      opcSseCustomerKey: "dGVzdC1rZXk=",
+      opcSseCustomerKeySha256: "dGVzdC1zaGE="
+    )
+
+    let req = await recorder.last
+    #expect(req?.httpMethod == "HEAD")
+    #expect(req?.value(forHTTPHeaderField: "opc-sse-customer-algorithm") == "AES256")
+    #expect(req?.value(forHTTPHeaderField: "opc-sse-customer-key") == "dGVzdC1rZXk=")
+    #expect(req?.value(forHTTPHeaderField: "opc-sse-customer-key-sha256") == "dGVzdC1zaGE=")
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #96. `ObjectStorageClient.getObject(range:)` accepted a `range` argument and threaded it all the way to `ObjectStorageRouter`, but the router's `headers` property bound that position to `_` and only ever emitted `opc-client-request-id`. A ranged `GetObject` therefore sent **no `Range` header**, got HTTP 200 with the **whole object**, and reported no error — silent over-fetch, and silent data corruption for a caller that assumed it got only the requested window.

While fixing it I found the same router arm also dropped the customer-supplied encryption (SSE-C) headers for `getObject`, `getObjectWithPAR`, and `headObject`, and — compounding the range bug — both `getObject` variants rejected any status `!= 200`, so even once the `Range` header was sent, the resulting **206 Partial Content** would throw `unexpectedStatusCode`.

## Fix

Cross-checked against the Python SDK (`get_object` / `head_object`): `range` and `opc-sse-customer-*` are **headers**; `versionId` and the `httpResponse*` overrides are **query params** (already handled correctly in the Swift router's `queryItems`).

- Router: give `getObject` / `getObjectWithPAR` / `headObject` dedicated header arms that emit `range` (get variants only) and the three `opc-sse-customer-*` headers, alongside `opc-client-request-id`.
- Client: accept **200 and 206** in both `getObject` variants.

## Tests (all credential-free, run in CI)

- **ObjectStorageHermeticTests** — request-shape assertions using the recorder seam: the `Range` and SSE-C headers reach the wire; an unranged read sends **no** `Range`; a 206 body is returned intact. Covers `getObject`, the PAR variant, and `headObject`.
- **OCIFixtureReplayTests** + `Fixtures/getObjectRange.json` — replay of a **real 206 Partial Content** response captured from live OCI (sanitized).
- **OCICaptureTests** — a gated capture case (`captureGetObjectRange`, env-var driven) to refresh that fixture.

Both suites are already in the Linux CI `UNIT_TEST_FILTER`, so no workflow change was needed.

## Validation

- `swift test` on macOS and Linux (`swift:6.2`, arm64) — 13/13 green.
- `swift format` + lint clean on all touched files.
- **Live against real OCI** (compartment `oci-swift-sdk`): uploaded a 1024-byte object and did `getObject(range: "bytes=0-15")` through the fixed SDK — the server answered **206** with `content-range: bytes 0-15/1024` and the client returned exactly the 16-byte window.
